### PR TITLE
Improve spellchecker logic

### DIFF
--- a/.github/actions/spell-check/entrypoint.sh
+++ b/.github/actions/spell-check/entrypoint.sh
@@ -19,6 +19,6 @@ echo "--> Install spellchecker"
 npm install --global spellchecker-cli retext-syntax-urls retext-indefinite-article retext-repeated-words remark-frontmatter
 
 echo "--> spellcheck markdown files"
-IGNORE_REGEX="[0-9a-f]{7} [0-9A-Za-z_\-]{11}" # GitHub hashes and YouTube IDs
+IGNORE_REGEX="[0-9a-f]{7} (?=.*[0-9])[0-9A-Za-z_\-]{11}" # GitHub hashes and YouTube IDs
 IGNORE_FILES="!(content/team/mark-heckler/_index.md)" # Too much spanish
-spellchecker -q --no-suggestions -l en-US -f 'content/**/*.md' $IGNORE_FILES -i $IGNORE_REGEX --frontmatter-keys description -d custom_dict.txt --plugins frontmatter spell syntax-urls indefinite-article repeated-words
+spellchecker -q --no-suggestions -l en-US -f 'content/**/*.md' $IGNORE_FILES -i $IGNORE_REGEX --frontmatter-keys title Title description Description -d custom_dict.txt --plugins frontmatter spell syntax-urls indefinite-article repeated-words

--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -36,7 +36,9 @@ GitOps
 Helming
 hostname
 [I,i]ntegrations
+kitesurfing
 lifecycle
+Livelessons
 [M,m]odelling
 modularity
 ([M,m]|multi-m)icroservice(s)?(-related)?
@@ -153,6 +155,7 @@ JPA
 JSON
 LDAP
 MDN
+MVB(-awarded)?
 ok
 youtube
 integrations
@@ -180,7 +183,9 @@ Czarkowski('s)?
 Gibb
 Iberkleid
 Jakub
+Jernigan
 Madhav
+Pilimon
 Sathe
 Schutta
 Vetter


### PR DESCRIPTION
- Assumes youtube id strings in shortcodes will have at least one number to avoid matching random 11-character misspelled words.
- Also checks titles for spelling errors as well.
- Allows for title or description fields to be capitalized and still checked