### PR TITLE
Handle in-page anchor links with fixed header

### DIFF
--- a/themes/docsy/assets/js/base.js
+++ b/themes/docsy/assets/js/base.js
@@ -118,13 +118,26 @@ limitations under the License.
           return false;
         });
 
-
         //Toggle mobile menu
         $("#menu-toggle").click(function(){
           $(".td-navbar .td-navbar-nav-hamburger").toggleClass("open");
           $(".td-navbar .td-navbar-nav-hamburger .navbar-nav .nav-item").toggle();
         });
 
+        // Handle in-page anchor links with fixed header
+        $('a[href^="#"]').click(function(e) {
+            var headerHeight = 80;
+            var strId = this.hash.replace(":","\\:");
+            var anchorDest = this.href;
+            e.preventDefault();
+            $('html, body').animate(
+                { scrollTop: $(strId).offset().top - headerHeight },
+                0,
+                'linear',
+                function(){ 
+                    window.location.href = anchorDest; 
+                });
+        });
 
     });
 

--- a/themes/docsy/assets/js/base.js
+++ b/themes/docsy/assets/js/base.js
@@ -147,10 +147,7 @@ limitations under the License.
         $('html, body').animate(
             { scrollTop: $(targetId).offset().top - headerHeight },
             0,
-            'linear',
-            function(){ 
-                //window.location.href = anchorDest; 
-            }
+            'linear'
         );
     }
 

--- a/themes/docsy/assets/js/base.js
+++ b/themes/docsy/assets/js/base.js
@@ -126,21 +126,33 @@ limitations under the License.
 
         // Handle in-page anchor links with fixed header
         $('a[href^="#"]').click(function(e) {
-            var headerHeight = 80;
-            var strId = this.hash.replace(":","\\:");
-            var anchorDest = this.href;
+            window.location.href = this.href;
             e.preventDefault();
-            $('html, body').animate(
-                { scrollTop: $(strId).offset().top - headerHeight },
-                0,
-                'linear',
-                function(){ 
-                    window.location.href = anchorDest; 
-                });
+            scrollToTarget(this.hash);
+        });
+
+        // Scroll to the right place when loading in-page anchor links
+        $(window).on('load', function(e){
+            var target = window.location.hash;
+            if (target) {
+                scrollToTarget(target);
+            }
         });
 
     });
 
+    function scrollToTarget(target) {
+        var headerHeight = 80;
+        var targetId = target.replace(":","\\:");
+        $('html, body').animate(
+            { scrollTop: $(targetId).offset().top - headerHeight },
+            0,
+            'linear',
+            function(){ 
+                //window.location.href = anchorDest; 
+            }
+        );
+    }
 
     function bottomPos(element) {
         return element.offset().top + element.outerHeight();


### PR DESCRIPTION
This should fix the in-page # links on headings and footnotes so they are not hidden behind the fixed header, but maintains the URL so we can link directly from anywhere.