### PR TITLE
Add notification under header when TanzuTV is live

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # Default build settings
 [context.production]
   publish = "public"
-  command = "git submodule update -f --init --recursive && npm install && hugo -b https://tanzu.vmware.com/developer"
+  command = "git submodule update -f --init --recursive && npm install && hugo -b https://tanzu.vmware.com/developer --minify"
 
 [context.production.environment]
   HUGO_VERSION = "0.69.2"

--- a/themes/docsy/assets/js/base.js
+++ b/themes/docsy/assets/js/base.js
@@ -126,9 +126,11 @@ limitations under the License.
 
         // Handle in-page anchor links with fixed header
         $('a[href^="#"]').click(function(e) {
-            window.location.href = this.href;
-            e.preventDefault();
-            scrollToTarget(this.hash);
+            if (this.hash.length > 1) { // don't do this for empty # links
+                window.location.href = this.href;
+                e.preventDefault();
+                scrollToTarget(this.hash);
+            }
         });
 
         // Scroll to the right place when loading in-page anchor links
@@ -139,10 +141,12 @@ limitations under the License.
             }
         });
 
-    });
+    });  
 
     function scrollToTarget(target) {
-        var headerHeight = 80;
+        var headerHeight = 80; 
+        if (document.getElementById("live-notify").style.display == "block")
+            headerHeight = headerHeight + 40;
         var targetId = target.replace(":","\\:");
         $('html, body').animate(
             { scrollTop: $(targetId).offset().top - headerHeight },
@@ -150,6 +154,14 @@ limitations under the License.
             'linear'
         );
     }
+
+    var check = isTvShowLive();
+    if (check) {
+        document.getElementsByClassName("td-main")[0].style.marginTop = 40;
+        document.getElementById("live-show-name").innerHTML = liveShowName;
+        document.getElementById("live-notify").href = liveShowLink;
+        document.getElementById("live-notify").style.display = "block";
+    }   
 
     function bottomPos(element) {
         return element.offset().top + element.outerHeight();

--- a/themes/docsy/assets/js/head.js
+++ b/themes/docsy/assets/js/head.js
@@ -31,3 +31,21 @@ function isTvShowLive(showName) {
 
       return isLive;
 }
+
+var savedTheme = localStorage.getItem("light-dark-mode-storage") || "dark";
+changeTheme(savedTheme);
+function changeTheme(mode) {
+    if (mode === "light") {
+      var head = document.head;
+      var link = document.createElement("link");
+
+      link.type = "text/css";
+      link.rel = "stylesheet";
+      link.href = {{ printf "%s" "/css/light-theme.css" | relURL }};
+      link.id = "light-theme"
+
+      head.prepend(link);
+      
+      document.documentElement.classList.add('light-mode')
+    } 
+}

--- a/themes/docsy/assets/js/head.js
+++ b/themes/docsy/assets/js/head.js
@@ -41,7 +41,7 @@ function changeTheme(mode) {
 
       link.type = "text/css";
       link.rel = "stylesheet";
-      link.href = {{ printf "%s" "/css/light-theme.css" | relURL }};
+      link.href = "{{ printf "%s" "/css/light-theme.css" | relURL }}";
       link.id = "light-theme"
 
       head.prepend(link);

--- a/themes/docsy/assets/js/live-notify.js
+++ b/themes/docsy/assets/js/live-notify.js
@@ -1,0 +1,33 @@
+var liveShowName, liveShowLink;
+function isTvShowLive(showName) {   
+
+  var episodeShowNames = [], episodeLinks = [], episodeDates = [], episodeTimes = [], episodeLengths = [];
+      {{ range where (where .Site.Pages "Type" "tv-episode") "Date.YearDay" "ge" now.YearDay }}  
+        var epDate = new Date("{{ .Params.Date }}");
+        episodeDates.push(epDate.toLocaleDateString());
+        episodeTimes.push(epDate.toLocaleTimeString());
+        episodeLengths.push({{ .Params.minutes }});
+        episodeShowNames.push("{{ .Parent.Title }}");
+        episodeLinks.push("{{ .Parent.Permalink | relURL }}");
+      {{ end }}
+      var currentDate = (new Date(Date.now())).toLocaleDateString();
+      var index = episodeDates.indexOf(currentDate);
+      var isLive = false;
+      if (index > -1) {
+        var startTime = (new Date(episodeDates[index] + " " + episodeTimes[index])).getTime();
+        var endTime = startTime + (episodeLengths[index] * 60 * 1000);
+        var currentTime = (new Date(Date.now())).getTime();
+        
+        if (showName == null)
+          isLive = (currentTime < endTime && currentTime > startTime); 
+        else
+          isLive = (currentTime < endTime && currentTime > startTime && episodeShowNames[index] == showName); 
+        
+        if (isLive) {
+          liveShowName = episodeShowNames[index];
+          liveShowLink = episodeLinks[index];
+        }
+      }
+
+      return isLive;
+}

--- a/themes/docsy/assets/scss/_custom.scss
+++ b/themes/docsy/assets/scss/_custom.scss
@@ -780,6 +780,31 @@ body.tv-episode {
   }
 }
 
+#live-notify {
+  display:none;
+  width: 100%;
+  text-align: center;
+  position:fixed;
+  z-index:20;
+  height:40px;
+  top:80px;
+  padding: 8px 0;
+  color: white;
+  background: #78BE20;
+}
+
+#live-notify .btn {
+  border-radius: 40px;
+  background: white;
+  font-size: .8em;
+  font-weight: 500;
+  padding: 2px 10px 1px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: black;
+  margin-right: 10px;
+}
+
 /* SYNTAX HIGHLIGHTING */
 
 /* Background */ .chroma, pre, code { color: #f8f8f2; background-color: #0f171c }

--- a/themes/docsy/layouts/_default/baseof.html
+++ b/themes/docsy/layouts/_default/baseof.html
@@ -9,6 +9,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-default td-outer">
+      {{ partial "live-notify.html" . }}
       <main role="main" class="td-main mt-lg-5 pt-lg-4 pt-md-5">
         {{ block "main" . }}{{ end }}
       </main>

--- a/themes/docsy/layouts/advocates/baseof.html
+++ b/themes/docsy/layouts/advocates/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/blog/baseof.html
+++ b/themes/docsy/layouts/blog/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/guides/baseof.html
+++ b/themes/docsy/layouts/guides/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/guides/single.html
+++ b/themes/docsy/layouts/guides/single.html
@@ -9,6 +9,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         <div class="row flex-xl-nowrap container mx-auto">
           <div class="col-12 col-md-3 col-lg-3 col-xl-3 td-sidebar d-print-none">

--- a/themes/docsy/layouts/partials/baseof.html
+++ b/themes/docsy/layouts/partials/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         <div class="row flex-xl-nowrap">
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -9,43 +9,13 @@
 </script>
 {{ end }}
 
-<script>
-
-var liveShowName, liveShowLink;
-function isTvShowLive(showName) {   
-
-  var episodeShowNames = [], episodeLinks = [], episodeDates = [], episodeTimes = [], episodeLengths = [];
-      {{ range where (where .Site.Pages "Type" "tv-episode") "Date.YearDay" "ge" now.YearDay }}  
-        var epDate = new Date("{{ .Params.Date }}");
-        episodeDates.push(epDate.toLocaleDateString());
-        episodeTimes.push(epDate.toLocaleTimeString());
-        episodeLengths.push({{ .Params.minutes }});
-        episodeShowNames.push({{ .Parent.Title }});
-        episodeLinks.push({{ .Parent.Permalink | relURL }});
-      {{ end }}
-      var currentDate = (new Date(Date.now())).toLocaleDateString();
-      var index = episodeDates.indexOf(currentDate);
-      var isLive = false;
-      if (index > -1) {
-        var startTime = (new Date(episodeDates[index] + " " + episodeTimes[index])).getTime();
-        var endTime = startTime + (episodeLengths[index] * 60 * 1000);
-        var currentTime = (new Date(Date.now())).getTime();
-        
-        if (showName == null)
-          isLive = (currentTime < endTime && currentTime > startTime); 
-        else
-          isLive = (currentTime < endTime && currentTime > startTime && episodeShowNames[index] == showName); 
-        
-        if (isLive) {
-          liveShowName = episodeShowNames[index];
-          liveShowLink = episodeLinks[index];
-        }
-      }
-
-      return isLive;
-}
-
-</script>
+{{ $jsLiveTv := resources.Get "js/live-notify.js" | resources.ExecuteAsTemplate "js/live-notify.js" . }}
+{{ if .Site.IsServer }}
+<script src="{{ $jsLiveTv.RelPermalink }}"></script>
+{{ else }}
+{{ $js := $js | minify | fingerprint }}
+<script src="{{ $jsLiveTv.RelPermalink }}" integrity="{{ $jsLiveTv.Data.Integrity }}" crossorigin="anonymous"></script>
+{{ end }}
 
 <script>
   var savedTheme = localStorage.getItem("light-dark-mode-storage") || "dark";

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -10,6 +10,44 @@
 {{ end }}
 
 <script>
+
+var liveShowName, liveShowLink;
+function isTvShowLive(showName) {   
+
+  var episodeShowNames = [], episodeLinks = [], episodeDates = [], episodeTimes = [], episodeLengths = [];
+      {{ range where (where .Site.Pages "Type" "tv-episode") "Date.YearDay" "ge" now.YearDay }}  
+        var epDate = new Date("{{ .Params.Date }}");
+        episodeDates.push(epDate.toLocaleDateString());
+        episodeTimes.push(epDate.toLocaleTimeString());
+        episodeLengths.push({{ .Params.minutes }});
+        episodeShowNames.push({{ .Parent.Title }});
+        episodeLinks.push({{ .Parent.Permalink | relURL }});
+      {{ end }}
+      var currentDate = (new Date(Date.now())).toLocaleDateString();
+      var index = episodeDates.indexOf(currentDate);
+      var isLive = false;
+      if (index > -1) {
+        var startTime = (new Date(episodeDates[index] + " " + episodeTimes[index])).getTime();
+        var endTime = startTime + (episodeLengths[index] * 60 * 1000);
+        var currentTime = (new Date(Date.now())).getTime();
+        
+        if (showName == null)
+          isLive = (currentTime < endTime && currentTime > startTime); 
+        else
+          isLive = (currentTime < endTime && currentTime > startTime && episodeShowNames[index] == showName); 
+        
+        if (isLive) {
+          liveShowName = episodeShowNames[index];
+          liveShowLink = episodeLinks[index];
+        }
+      }
+
+      return isLive;
+}
+
+</script>
+
+<script>
   var savedTheme = localStorage.getItem("light-dark-mode-storage") || "dark";
   changeTheme(savedTheme);
   function changeTheme(mode) {

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -13,7 +13,7 @@
 {{ if .Site.IsServer }}
 <script src="{{ $jsLiveTv.RelPermalink }}"></script>
 {{ else }}
-{{ $js := $js | minify | fingerprint }}
+{{ $jsLiveTv := $jsLiveTv | minify | fingerprint }}
 <script src="{{ $jsLiveTv.RelPermalink }}" integrity="{{ $jsLiveTv.Data.Integrity }}" crossorigin="anonymous"></script>
 {{ end }}
 

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -9,33 +9,14 @@
 </script>
 {{ end }}
 
-{{ $jsLiveTv := resources.Get "js/live-notify.js" | resources.ExecuteAsTemplate "js/live-notify.js" . }}
+{{ $jsHead := resources.Get "js/head.js" | resources.ExecuteAsTemplate "js/head.js" . }}
 {{ if .Site.IsServer }}
-<script src="{{ $jsLiveTv.RelPermalink }}"></script>
+<script src="{{ $jsHead.RelPermalink }}"></script>
 {{ else }}
-{{ $jsLiveTv := $jsLiveTv | minify | fingerprint }}
-<script src="{{ $jsLiveTv.RelPermalink }}" integrity="{{ $jsLiveTv.Data.Integrity }}" crossorigin="anonymous"></script>
+{{ $jsHead := $jsHead | minify | fingerprint }}
+<script src="{{ $jsHead.RelPermalink }}" integrity="{{ $jsHead.Data.Integrity }}" crossorigin="anonymous"></script>
 {{ end }}
 
-<script>
-  var savedTheme = localStorage.getItem("light-dark-mode-storage") || "dark";
-  changeTheme(savedTheme);
-  function changeTheme(mode) {
-      if (mode === "light") {
-			  var head = document.head;
-			  var link = document.createElement("link");
-
-			  link.type = "text/css";
-			  link.rel = "stylesheet";
-			  link.href = {{ printf "%s" "/css/light-theme.css" | relURL }};
-			  link.id = "light-theme"
-
-			  head.prepend(link);
-				
-				document.documentElement.classList.add('light-mode')
-      } 
-  }
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}

--- a/themes/docsy/layouts/partials/live-notify.html
+++ b/themes/docsy/layouts/partials/live-notify.html
@@ -1,0 +1,1 @@
+<a href="#" id="live-notify"><span class="btn">Live</span><span id="live-show-name"></span> is streaming live. Watch now.</a>

--- a/themes/docsy/layouts/samples/baseof.html
+++ b/themes/docsy/layouts/samples/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/taxonomy/baseof.html
+++ b/themes/docsy/layouts/taxonomy/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/team/baseof.html
+++ b/themes/docsy/layouts/team/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/topics/topic.html
+++ b/themes/docsy/layouts/topics/topic.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+        {{ partial "live-notify.html" . }}
       <div class="td-main ">
         <div class="bg-gray-dark mt-lg-5 mt-0 py-lg-5 py-2">
             <div class='container'>

--- a/themes/docsy/layouts/tv-show/list.html
+++ b/themes/docsy/layouts/tv-show/list.html
@@ -9,34 +9,18 @@
    
     {{ if .Params.streaming }}
     <div id="twitch-embed"></div>
+
     <script src="https://embed.twitch.tv/embed/v1.js"></script>
     <script type="text/javascript">
    
-      var episodeDates = [], episodeTimes = [], episodeLengths = [];
-      {{ range .Data.Pages }}  
-        var epDate = new Date("{{ .Params.Date }}");
-        episodeDates.push(epDate.toLocaleDateString());
-        episodeTimes.push(epDate.toLocaleTimeString());
-        episodeLengths.push({{ .Params.minutes }});
-      {{ end }}
-
-      var currentDate = (new Date(Date.now())).toLocaleDateString();
-      var index = episodeDates.indexOf(currentDate);
-      if (index > -1) {
-        var startTime = (new Date(episodeDates[index] + " " + episodeTimes[index])).getTime();
-        var endTime = startTime + (episodeLengths[index] * 60 * 1000);
-        var currentTime = (new Date(Date.now())).getTime();
+      var check = isTvShowLive("{{ .Title }}");
+      if (check) {
         
-        if (currentTime < endTime && currentTime > startTime) {
-          
-          new Twitch.Embed("twitch-embed", {
-              width: 1130,
-              height: 480,
-              channel: "makejarnotwar",
-          });
-          
-        }
-
+        new Twitch.Embed("twitch-embed", {
+            width: 1130,
+            height: 480,
+            channel: "makejarnotwar",
+        });
       }
 
     </script>

--- a/themes/docsy/layouts/tv/baseof.html
+++ b/themes/docsy/layouts/tv/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}

--- a/themes/docsy/layouts/videos/baseof.html
+++ b/themes/docsy/layouts/videos/baseof.html
@@ -10,6 +10,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
+      {{ partial "live-notify.html" . }}
       <div class="td-main">
         
         {{ block "main" . }}{{ end }}


### PR DESCRIPTION
I think I got this working, and should let us reuse the JS as needed on other pages.

To test this locally, create a dummy episode under a Tanzu TV show folder and set the date and time so that the current time falls into the window. You can set draft=true for it to see behavior with and without the banner.

Also, to minimize the number of episodes loaded in the JS, it will only include any episodes that occur after the build time of the site.