### PR TITLE
Fix logic for upcoming episodes display on Tanzu TV

### DIFF
--- a/content/tv/springone-tour/_index.md
+++ b/content/tv/springone-tour/_index.md
@@ -3,7 +3,7 @@ title: "SpringOne Tour"
 type: "tv-show"
 streaming: true
 id: "springone-tour"
-description: Join us each month for a two-day, live event where your cloud native community favorites go in depth on different topics.
+description: Join us each month for a two-day, live event where your cloud native community favorites go in depth on different topics. Register at [SpringOne Tour](https://springonetour.io/) or watch below.
 teaser: Live Every Month
 image: "/images/tv/shows/springone-tour.png"
 weight: 2

--- a/themes/docsy/layouts/partials/episode-index.html
+++ b/themes/docsy/layouts/partials/episode-index.html
@@ -2,51 +2,56 @@
     {{ $pages := sort (where .Site.Pages "Section" "tv") }}
     {{ $parent := .Page }}
     {{ $.Scratch.Set "upcoming" false }}
+
     <div class='container episodes'>
-
-        {{ if .Params.streaming }}
-        <div class="col px-0">
-            <h3 class="mt-5 mb-4">Upcoming Episodes</h3>
-            <div class="row justify-content-between mb-5">
-            {{ range sort $pages "Params.Date" "asc" }}
-                {{ if and (eq .Parent $parent) (gt now .Params.PublishDate) }}
+        {{ range sort $pages "Params.Date" "asc" }}
+            {{ if and (eq .Parent $parent) (gt .Params.Date.Unix now.Unix) }}
                 {{ $.Scratch.Set "upcoming" true }}
-                {{ printf "<div class=\"upcoming col-lg-6 col-12 px-0 mb-5\" data-episode-date=\"%s\">" (.Date.Format "2006-01-02T15:04:05-07:00") | safeHTML }}
-                    <div class="col-lg-11 col-12 px-0">
-                        {{ $.Scratch.Set "episodeLink" .RelPermalink }}
-                        {{ if (isset .Params "register") | and (not (eq .Params.register "")) }}
-                            {{ $.Scratch.Set "episodeLink" .Params.register }}
-                        {{ end }}
-                        {{ $episodeLink := $.Scratch.Get "episodeLink" }}
-                        <a href="{{ $episodeLink }}"><img src="{{ .Params.episode_banner | relURL }}"></a>
-                        <p class="teaser auto mt-4 pt-3">Streaming {{ .Params.Date.Format "January 2" }} on Twitch</p>
-                        <h3 class="pt-2"><a class="text-white" href="{{ $episodeLink }}">{{- .Title -}}</a></h3>
-                    </div>
-                </div>
-                {{ end }}
             {{ end }}
-            {{ if eq ($.Scratch.Get "upcoming") false }}
-                <div class="col-lg-6 col-12 px-lg-3 px-0 mb-5 mb-lg-5 mb-lg-0">
-                <p>Check back soon for more upcoming episodes.</p>
-                </div>
-            {{ end }}
-            </div>
-        </div>
-        <script type="text/javascript">
-        var upcoming = document.querySelectorAll(".upcoming");
-        var currentTime = Date.now();
-	    upcoming.forEach(episode => {
-            var episodeTime = new Date(episode.dataset.episodeDate).getTime();
-            if (episodeTime < currentTime) {
-                episode.style.display = "none";
-            }
-	    });
-        </script>
-
-
         {{ end }}
 
-        <div class="col px-lg-0 pt-5 {{ if .Params.Streaming }}border-top{{ end }} mb-5">
+        {{ if ($.Scratch.Get "upcoming") true }}
+            {{ if .Params.streaming }}
+            <div class="col px-0">
+                <h3 class="mt-5 mb-4">Upcoming Episodes</h3>
+                <div class="row justify-content-between mb-5">
+                {{ range sort $pages "Params.Date" "asc" }}
+                    {{ if and (eq .Parent $parent) (gt .Params.Date.Unix now.Unix) }}
+                    {{ printf "<div class=\"upcoming col-lg-6 col-12 px-0 mb-5\" data-episode-date=\"%s\">" (.Date.Format "2006-01-02T15:04:05-07:00") | safeHTML }}
+                        <div class="col-lg-11 col-12 px-0">
+                            {{ $.Scratch.Set "episodeLink" .RelPermalink }}
+                            {{ if (isset .Params "register") | and (not (eq .Params.register "")) }}
+                                {{ $.Scratch.Set "episodeLink" .Params.register }}
+                            {{ end }}
+                            {{ $episodeLink := $.Scratch.Get "episodeLink" }}
+                            <a href="{{ $episodeLink }}"><img src="{{ .Params.episode_banner | relURL }}"></a>
+                            <p class="teaser auto mt-4 pt-3">Streaming {{ .Params.Date.Format "January 2" }} on Twitch</p>
+                            <h3 class="pt-2"><a class="text-white" href="{{ $episodeLink }}">{{- .Title -}}</a></h3>
+                        </div>
+                    </div>
+                    {{ end }}
+                {{ end }}
+                </div>
+            </div>
+            <script type="text/javascript">
+            var upcoming = document.querySelectorAll(".upcoming");
+            var currentTime = Date.now();
+            upcoming.forEach(episode => {
+                var episodeTime = new Date(episode.dataset.episodeDate).getTime();
+                if (episodeTime < currentTime) {
+                    episode.style.display = "none";
+                }
+            });
+            </script>
+            {{ end }}
+        {{ end }}
+
+        {{ $noUpcoming := false }}
+        {{ if (or (($.Scratch.Get "upcoming") true) .Params.Streaming) }}
+            {{ $noUpcoming := true }}
+        {{ end }}
+
+        <div class="col px-lg-0 pt-5 {{ if $noUpcoming }} border-top{{ end }} mb-5">
             {{ if .Params.Streaming }}
             <h3 class="mb-4">Watch Past Episodes</h3>
             {{ end }}

--- a/themes/docsy/layouts/tv-show/list.html
+++ b/themes/docsy/layouts/tv-show/list.html
@@ -5,7 +5,7 @@
   	<div class="container">
 		{{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
     <h1 class="h1 mt-4 pt-2"> {{- .Title -}}</h1>
-		<div class="lead"><p>{{- .Params.description}}</p></div>
+		<div class="lead"><p>{{- .Params.description | markdownify }}</p></div>
 
     {{ if .Params.streaming }}
     <div id="twitch-embed"></div>


### PR DESCRIPTION
@paulczar Rachel and Chloe mentioned the "Upcoming Episodes" logic wasn't working (see S1T page). This should fix it. Take a look if you don't mind.

(Also though, I think we need to add the upcoming August S1T sessions as MD files in the content folder...)