### PR TITLE
Expand format on upcoming timestamps

### DIFF
--- a/themes/docsy/layouts/tv-episode/single.html
+++ b/themes/docsy/layouts/tv-episode/single.html
@@ -27,7 +27,7 @@
         <a class="play-icon float-left" href='{{ $.Scratch.Get "streamUrl" }}'></a>
         <div class="float-left ml-3 pl-1">
           <a href='{{ $.Scratch.Get "streamUrl" }}'>Watch {{ ($.Scratch.Get "streamName") }}</a><br/>
-          <span class="text-white">{{ .Params.Date.Local.Format "3 PM MST" }} on {{ .Params.Date.Format "Monday, Jan 02, 2006" }}</span>
+          <span class="text-white">{{ .Params.Date.Local.Format "3:04 PM MST" }} on {{ .Params.Date.Format "Monday, Jan 02, 2006" }}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Show "2:00 PM" instead of "2 PM". Without this, times on the half-hour mark (ie. 2:30) would still show as 2 PM