### PR TITLE
Practice page formatting and 'remote' area cleanup

### DIFF
--- a/content/practices/assumptions/index.md
+++ b/content/practices/assumptions/index.md
@@ -63,19 +63,19 @@ This exercise could go long if there are many assumptions or you're having troub
 
 ## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 
 None at the moment
 
-## Following
+### Following
 [Exploratory Interviews](/practices/exploratory-interviews)
 
-### Real World Examples
+## Real World Examples
 ![Image of a two by two chart plotting assumptions by likelihood to kill business and amount of evidence](/images/practices/assumptions/example-2.jpg)
 
-### Recommended Reading
+## Recommended Reading
 

--- a/content/practices/boris/index.md
+++ b/content/practices/boris/index.md
@@ -118,23 +118,23 @@ In many ways this is true about any practice, so similar wisdom and optimization
 
 Also acknowledge that it will take several sessions to go through the “I do, we do, you do” process - more opportunities to facilitate can help mitigate this.
 
-### Related Practices
+## Related Practices
 
 Boris is an activity within the [Swift Method](/practices/swift-method).
 
-## Preceding
+### Preceding
 
 [Event Storming](/practices/event-storming)
 
-## Following
+### Following
 
 None at the moment
 
-### Real World Examples
+## Real World Examples
 
 See the <a href="https://miro.com/app/board/o9J_kzaSk0E=/" target="_blank">Event Storming and Boris Training Miro board</a> for a detailed description of Boris and the [Swift Method](/practices/swift-method) of modernization for an Uber Eats-style application
 
-### Recommended Reading
+## Recommended Reading
 
 <a href="https://www.youtube.com/watch?v=7-fRtd8LUwA" target="_blank">Swift Method: Event Storming, Boris the Spider and Other Techniques</a> (YouTube video) talk at ExploreDDD 2019 by Shaun Anderson
 

--- a/content/practices/design-critique/index.md
+++ b/content/practices/design-critique/index.md
@@ -73,20 +73,20 @@ You know you’re done when all comments have been reviewed and all problems hav
 
 Regardless of how you decide to run your design critique, you should ensure that a room is booked and any supplies (such as sticky notes, sharpies, and tape) are available.
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 None at the moment
 
-## Preceding
+### Preceding
 None at the moment
 
-## Following
+### Following
 None at the moment
 
-### Real World Examples
+## Real World Examples
 ![Design printout with feedback attached using sticky notes](/images/practices/design-critique/example-2.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 <a href="http://shop.oreilly.com/product/0636920033561.do" target="_blank">Discussing Design</a> by Adam Conner and Aaron Irizarry

--- a/content/practices/design-studio/index.md
+++ b/content/practices/design-studio/index.md
@@ -69,22 +69,22 @@ The top ideas that came out of the design studio will be carried forward and syn
 - Be sure to focus on the user journeys
 - You can use any variety of paper sizes and squares; it’s about generating quantity, not detail
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Personas](/practices/personas)
 - [Journey Map](/practices/journey-map)
 - [Scenario Writing](/practices/scenario-writing)
 
-## Following
+### Following
 None at the moment
 
-### Real World Examples
+## Real World Examples
 Coming soon.
 
-### Recommended Reading
+## Recommended Reading
 None at the moment

--- a/content/practices/draw-toast/index.md
+++ b/content/practices/draw-toast/index.md
@@ -54,22 +54,22 @@ Sometimes people say “Do I have to draw? I don’t know how to draw.” Genera
 
 If short on time, have everyone tape theirs up and just ask participants to take a look during a break.
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 None at the moment
 
-## Preceding
+### Preceding
 None at the moment
 
-## Following
+### Following
 None at the moment
 
-### Real World Examples
+## Real World Examples
 ![Wide view of different toast drawings taped to a window wall](/images/practices/draw-toast/example-1.png)
 
 ![Close up of one drawing of how to make toast](/images/practices/draw-toast/example-2.png)
 
-### Recommended Reading
+## Recommended Reading
 
 <a href="http://www.drawtoast.com/" target="_blank">DrawToast.com</a> has a wealth of information including a TED talk and examples of others' work on this subject. One particularly helpful resource is <a href="http://www.drawtoast.com/downloads/DrawToast%20Systems%20Thinking%20Guide.pdf" target="_blank">A Primer in Systems Thinking</a> (PDF).

--- a/content/practices/event-storming/index.md
+++ b/content/practices/event-storming/index.md
@@ -105,24 +105,24 @@ You know you’ve finished when you have:
 
 **An Event Storming is only successful if the right people are involved.** This is a mix of business domain experts, customer executives, stakeholders, business analysts, software developers, architects, testers, and folks who support the product in production. Subject matter experts, product owners and developers that knows and understands the application domain. This process enables cross perspective conversation throughout the team as well as a standard definition of the terms used by both technical and non-technical team members.
 
-### Related Practices
+## Related Practices
 
 Event Storming is an activity within the [Swift Method](/practices/swift-method).
 
-## Preceding
+### Preceding
 
 None at the moment
 
-## Following
+### Following
 
 [Boris](/practices/boris)
 
-### Real World Examples
+## Real World Examples
 
 <a href="https://www.youtube.com/watch?v=by8SdfF56vI" target="_blank">Deconstructing Monoliths With Domain Driven Design</a>  
 <a href="https://miro.com/app/board/o9J_kzaSk0E=/" target="_blank">WeBeFoods Example Mock (via Miro)</a>  
 
-### Recommended Reading
+## Recommended Reading
 
 Motivation for the Event Storming exercise:  
 <a href="https://www.amazon.com/Gamestorming-Playbook-Innovators-Rulebreakers-Changemakers/dp/0596804172" target="_blank">Gamestorming: A Playbook for Innovators, Rulebreakers, and Changemakers</a> by Dave Gray, Sunni Brown, and James Macanufo

--- a/content/practices/goals-anti-goals/index.md
+++ b/content/practices/goals-anti-goals/index.md
@@ -54,20 +54,20 @@ Success is when the core team and stakeholders have a clear and shared understan
 
 If you have a lot of people in your Kickoff (e.g. 15+), consider asking everyone to organize themselves into groups of 3-4 people. This will simplify the process of sharing out and affinity mapping the generated goals.
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 
 ![Whiteboard with business, product, project, consulting engagement, and anti-goals written out](/images/practices/goals-anti-goals/example-3.jpg)

--- a/content/practices/insight-prioritization/index.md
+++ b/content/practices/insight-prioritization/index.md
@@ -51,13 +51,13 @@ Success is achieved when the team agrees to the top 3-5 Insights on which it wil
 
 None at the moment
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Problem Prioritization](/practices/problem-prioritization)
 - [Research Synthesis](/practices/research-synthesis)
 
@@ -65,13 +65,13 @@ None at the moment
 
 [Problem Prioritization](/practices/problem-prioritization)
 
-## Following
+### Following
 
 [Solution Brainstorming](/practices/solution-brainstorming)
 
-### Real World Examples
+## Real World Examples
 Coming soon!
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/journey-map/index.md
+++ b/content/practices/journey-map/index.md
@@ -66,25 +66,25 @@ At the end of a Journey Map the team will have a shared holistic view of a Perso
  to consider, map them as touch points from a single [Personas](/practices/personas) perspective.
 - To understand more detail and complexity consider using a Service Blueprint to map a product/service’s “backstage actions” and “support processes” to an individual customer journey.
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Personas](/practices/personas)
 - [Research Synthesis](/practices/research-synthesis)
 
-## Following
+### Following
 [Service Blueprint](/practices/service-blueprint)
 [Scenario Writing](/practices/scenario-writing)
 
-### Real World Examples
+## Real World Examples
 
 ![Journey map on a whiteboard example](/images/practices/journey-map/example-1.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 [Design Sprint journey mapping technique](https://sprintstories.com/the-design-sprint-note-n-map-a9bf0ca88f51)  
 [The difference between a journey map and a service blueprint](https://blog.practicalservicedesign.com/the-difference-between-a-journey-map-and-a-service-blueprint-31a6e24c4a6c)  

--- a/content/practices/lean-business-canvas/index.md
+++ b/content/practices/lean-business-canvas/index.md
@@ -66,25 +66,25 @@ Success is when you have agreement and understanding of the product market fit, 
 - Revenue is one way to measure success, that box could be renamed to **Outcomes**
 - Update this business model week over week, it’s meant to be used over time.
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Molecule Map](/practices/molecule-map)
 - [Personas](/practices/personas)
 
-## Following
+### Following
 
 None at the moment
 
-### Real World Examples
+## Real World Examples
 
 ![Sample filled out canvas](/images/practices/lean-business-canvas/example-1.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 [Business Model Generation book](https://www.strategyzer.com/books/business-model-generation)  
 [Business Model Canvas Yelp](https://www.innovationtactics.com/business-model-canvas-yelp/)

--- a/content/practices/molecule-map/index.md
+++ b/content/practices/molecule-map/index.md
@@ -47,26 +47,26 @@ Success is when you have agreement on the problem and solution (aka snapshot)to 
 
 None at the moment
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 
 ![Close up of a detailed molecule map drawn on a whiteboard with persona in the center](/images/practices/molecule-map/example-1.jpg)
 
 ![Close up of a molecule map drawn on a whiteboard](/images/practices/molecule-map/example-2.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/persona-ecosystem-map/index.md
+++ b/content/practices/persona-ecosystem-map/index.md
@@ -44,23 +44,23 @@ The team has a shared understanding of all the users, what they care about, and 
 
 None at the moment
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 Coming soon!
  
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/personas/index.md
+++ b/content/practices/personas/index.md
@@ -63,21 +63,21 @@ Success is when you've created a "master persona" and everyone in the room feels
 
 None at the moment
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 
 ![Team member presenting a persona while everyone watches and listens](/images/practices/personas/example-1.png)
 
@@ -87,6 +87,6 @@ None at the moment
 
 ![Example of a digital persona template](/images/practices/personas/example-5.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/problem-prioritization/index.md
+++ b/content/practices/problem-prioritization/index.md
@@ -51,25 +51,25 @@ Success is achieved when the team agrees to the top 3-5 problems on which it wil
 
 The timing of this activity varies along with the number of problems identified in the research process, so prepare accordingly. It can also be beneficial to timebox conversation of each problem in order to ensure the team maintains forward momentum.
 
-### Related practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Research Synthesis](/practices/research-synthesis)
 
-## Following
+### Following
 - [Insight Prioritization](/practices/insight-prioritization)
 - [Solution Brainstorming](/practices/solution-brainstorming)
 
-### Real World Examples
+## Real World Examples
 ![Two by two chart plotting problems by frequency and intensity](/images/practices/problem-prioritization/example-2.jpg)
 
 ![A group of people discusses priority in front of a whiteboard with two by two chart on it](/images/practices/problem-prioritization/example-3.jpg)
 
 ![Two by two chart with top problems prioritized](/images/practices/problem-prioritization/example-5.jpg)
 
-### Recommended Reading
+## Recommended Reading
 

--- a/content/practices/product-valuation/index.md
+++ b/content/practices/product-valuation/index.md
@@ -123,17 +123,17 @@ Our advice is to remember that:
 - Estimating the product valuation is just adding details to the intuition that your stakeholders already have that this product is valuable.
 - The practice of making assumptions, building calculations on top of them, and making decisions based on those calculations is extremely common. People across industries do this every single day.
 
-### Related Practices
+## Related Practices
 
 In step 1 or 2, you may want to use a prioritization exercise similar to [Insight Prioritization](/practices/insight-prioritization).
 
-### Real World Examples
+## Real World Examples
 
 ![Example value slide showing how an MVP saves 60 minutes of time per document for a set of users with a future projection based on an assumed adoption rate](/images/practices/product-valuation/example-1.png)
 
 ![Another example value slide showing the number of developer hours saved with the team's solution in place](/images/practices/product-valuation/example-2.png)
 
-### Recommended Reading
+## Recommended Reading
 
 Coming soon: Christopher Hendrix’s summary of "How to Measure Anything”
 

--- a/content/practices/research-synthesis/index.md
+++ b/content/practices/research-synthesis/index.md
@@ -66,23 +66,23 @@ It's also helpful to share out findings at the subsequent iteration planning mee
 
 You can alternately create your categories from the questions you are asking to your identified [personas](/practices/personas). These categories only tend to work for users of the same persona (i.e. do not mix user interviews with stakeholder interviews while synthesizing)
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Assumptions](/practices/assumptions)
 - [Exploratory Interviews](/practices/exploratory-interviews)
 
-## Following
+### Following
 
 Various, depending on context
 
-### Real World Examples
+## Real World Examples
 Coming soon! 
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/risks-and-mitigations/index.md
+++ b/content/practices/risks-and-mitigations/index.md
@@ -64,23 +64,23 @@ Success is when you have a shared understanding of the biggest risks and have a 
 - Curtail finger pointing or unkind feedback
 - Ensure that the actions are actionable and not too general e.g., “Don’t do this…”  
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 ![Whiteboard table showing risks in one column and related mitigation strategies in another](/images/practices/risks-and-mitigations/example-2.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/scenario-writing/index.md
+++ b/content/practices/scenario-writing/index.md
@@ -76,24 +76,24 @@ How sheep farmers currently purchase sheep at actions in person
 Example of a **future state** scenario:  
 How sheep farmers will purchase sheep via the internet with the new product
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
  
-## Preceding
+### Preceding
 - [Personas](/practices/personas)
 - [Problem Prioritization](/practices/problem-prioritization)
 - [Insight Prioritization](/practices/insight-prioritization)  
 
-## Following
+### Following
 
 [Design Studio](/practices/design-studio)
 
-### Real World Examples
+## Real World Examples
 Coming soon! 
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/service-blueprint/index.md
+++ b/content/practices/service-blueprint/index.md
@@ -89,24 +89,24 @@ Optional lines to draw between rows
    -  _The line of visibility_ - beyond this line, the customer can no longer see into the service
    -  _The line of internal interaction_ - this is where the business itself stops, and partners step in
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 Coming soon! 
 
-### Recommended Reading
+## Recommended Reading
 
 <a href="https://www.izacross.com/thoughts/blueprintfoundations" target="_blank">Service Blueprints: Laying the Foundation</a> by Izac Ross of Cooper
 

--- a/content/practices/solution-brainstorming/index.md
+++ b/content/practices/solution-brainstorming/index.md
@@ -57,21 +57,21 @@ Success is achieved when you have extracted ideas that directly relate to your t
 
 You may need to adjust the timing depending on how many people are present. Be sure to give sufficient time for people to both read ideas and create new ideas (this is especially critical as you get further into the pass-and-brainstorm process).
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 - [Insight Prioritization](/practices/insight-prioritization)
 - [Problem Prioritization](/practices/problem-prioritization)
 
-## Following
+### Following
 - [Solution Grooming](/practices/solution-grooming)
 - [Solution Prioritization](/practices/solution-prioritization)
 
-### Real World Examples
+## Real World Examples
 Coming soon! 
 
-### Recommended Reading
+## Recommended Reading

--- a/content/practices/solution-grooming/index.md
+++ b/content/practices/solution-grooming/index.md
@@ -67,23 +67,23 @@ This workshop can run very long if there are a lot of ideas to cluster so be sur
 
 If needed, you can also lead the team in expanding / consolidating clusters to the team's satisfaction.
 
-### Related Practices
+## Related Practices
 
-## Variations
+### Variations
 
 None at the moment
 
-## Preceding
+### Preceding
 
 [Solution Brainstorming](/practices/solution-brainstorming)
 
-## Following
+### Following
 
 [Solution Prioritization](/practices/solution-prioritization)
 
-### Real World Examples
+## Real World Examples
 Coming soon! 
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/solution-prioritization/index.md
+++ b/content/practices/solution-prioritization/index.md
@@ -63,19 +63,19 @@ You know you are done when the team has prioritized their solutions and is comfo
 
 This is an activity that you can time box if it feels drawn out. Many of the tips embedded above are intended to help you avoid rabbit holes, but if that happens you should feel empowered to move things forward by refocusing the team, setting a timer, or forcing a decision.
 
-### Related Practices
+## Related Practices
 
-## Preceding
+### Preceding
 - [Solution Brainstorming](/practices/solution-brainstorming)
 - [Solution Grooming](/practices/solution-grooming)
 
-## Following
+### Following
 - [Scenario Walkthrough](/practices/scenario-walkthrough)
 - [Design Studio](/practices/design-studio)
 
-### Real World Examples
+## Real World Examples
 ![Digital two by two with prioritized solutions](/images/practices/solution-prioritization/example-6.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/stakeholder-map/index.md
+++ b/content/practices/stakeholder-map/index.md
@@ -64,21 +64,21 @@ You've succeeded when there exists a shared understanding of stakeholders involv
 
 This exercise has a tendency to go long. Your job is to keep each description brief and give the team people to follow up with.
 
-### Related Practices
+## Related Practices
 
-## Variations
-
-None at the moment
-
-## Preceding
+### Variations
 
 None at the moment
 
-## Following
+### Preceding
 
 None at the moment
 
-### Real World Examples
+### Following
+
+None at the moment
+
+## Real World Examples
 Coming soon! 
 
 ### Recommended reading

--- a/content/practices/story-mapping/index.md
+++ b/content/practices/story-mapping/index.md
@@ -69,19 +69,19 @@ A user task is a short verb phrase like “read an email” or “respond to a m
  
 Work on the happy path first. Then in the deep dive portion, capture the alternative paths a user might take through the product.
 
-### Related Practices
+## Related Practices
 
-## Preceding
+### Preceding
 
 Completion of Discovery & Framing
 
-## Following
+### Following
 
 Share out at Inception
 
-### Real World Examples
+## Real World Examples
 Coming soon! 
 
-### Recommended Reading
+## Recommended Reading
 
 

--- a/content/practices/swift-method/index.md
+++ b/content/practices/swift-method/index.md
@@ -67,19 +67,19 @@ A good facilitator should be able to drive out how a system should be designed b
 
 This notional architecture now represents a good first cut direction of the system. When used as a tool for modernizing existing systems, [Boris](/practices/boris) reveals the likely target architecture. Other activities in the Swift Method help define how to get from Current State to Modernized.
 
-### Related Practices
+## Related Practices
 Swift Method contains many activities, including:
 
 - [Event Storming](/practices/event-storming)
 - [Boris](/practices/boris)
 
-### Real World Examples
+## Real World Examples
 
 See the <a href="https://miro.com/app/board/o9J_kzaSk0E=/" target="_blank">Event Storming and Boris Training Miro board</a> for a detailed description of [Boris](/practices/boris) and the Swift Method of modernization for an Uber Eats-style application
 
 ![Visual of the Swift Method's various steps and how they flow into one another](/images/practices/swift-method/example-1.png)
 
-### Recommended Reading
+## Recommended Reading
 
 <a href="https://tanzu.vmware.com/content/white-papers/tackle-application-modernization-in-days-and-weeks-not-months-and-years" target="_blank">Tackle Application Modernization in Days and Weeks, Not Months and Years</a> (white paper)
 

--- a/content/practices/team-values/index.md
+++ b/content/practices/team-values/index.md
@@ -60,17 +60,17 @@ Every member of the “core” team should be involved in this activity. A helpf
 
 These team values can be leveraged again at the end of the project and/or consulting engagement if you decide to do a How We Work transition activity. This will allow the team to adjust their values and identify aligned practices they’ve done during the engagement to keep doing after they return home.
 
-### Related Practices
+## Related Practices
 
 Coming soon: How We Work
 
-### Real World Examples
+## Real World Examples
 
 ![Typed up list of grouped team values with a summarized value statement for each group](/images/practices/team-values/example-1.png)
 
 ![Summarized value statements up on the wall in team project area](/images/practices/team-values/example-2.jpeg)
 
-### Recommended Reading
+## Recommended Reading
 
 None at the moment
 

--- a/content/practices/ubiquitous-language/index.md
+++ b/content/practices/ubiquitous-language/index.md
@@ -71,21 +71,21 @@ If you find yourself running low on time during share out, consider prioritizing
 
 Try as hard as you can to have one or more domain experts in the room with you. Without people present who can represent the subject matter, it will be tougher to converge on a shared language that represents the business reality.
 
-### Related Practices
+## Related Practices
 
-## Preceding
-
-None at the moment.
-
-## Following
+### Preceding
 
 None at the moment.
 
-### Real World Examples
+### Following
+
+None at the moment.
+
+## Real World Examples
 
 ![example ubiquitous language workshop on whiteboard](/images/practices/ubiquitous-language/example-1.jpg)
 
-### Recommended Reading
+## Recommended Reading
 
 [Ubiquitous Language & the joy of naming](https://blog.carbonfive.com/2016/10/04/ubiquitous-language-the-joy-of-naming/)  
 [DDD: Questions around ubiquitous language](https://richarddingwall.name/2013/02/16/ubiquitious-language-handling-change/)  

--- a/themes/docsy/layouts/practices/single.html
+++ b/themes/docsy/layouts/practices/single.html
@@ -71,11 +71,6 @@
                         <p>There is currently a remote template available in Miro. Here you will find step
                             instructions on how to conduct this practice remotely including general tips and
                             info.
-                            <br/><br/>
-                            Disclaimer: In case you are not able to use Miro during your current
-                            engagement, please open the template using your Miro VMware account, take a
-                            print
-                            screen and copy it over to the tool you are using.
                         </p>
                     </div>
                     <div class="col-lg-4 px-2 px-lg-2 mb-3">


### PR DESCRIPTION
- Fix heading levels for all practice pages
- Remove confusing paragraphe for "Remote" practices