### PR TITLE
Fix styling of checkbox-item

### DIFF
--- a/themes/docsy/assets/scss/_custom.scss
+++ b/themes/docsy/assets/scss/_custom.scss
@@ -522,7 +522,11 @@ body.light-mode #toggle-light-dark-mode span {
       border-radius: 0;
       display: block;
     }
-    input[type=text]:focus, input[type=url]:focus, input[type=email]:focus, input[type=tel]:focus, select.mktoField:focus {
+    input[type="text"]:focus,
+    input[type="url"]:focus,
+    input[type="email"]:focus,
+    input[type="tel"]:focus,
+    select.mktoField:focus {
       outline: none !important;
       border-bottom: 1px solid $link !important;
     }
@@ -985,12 +989,6 @@ body.tv-episode {
 
 .checklist-item {
   padding: 0.5rem;
-  margin: 0.5rem 0;
-  display: flex;
-  border-left: 4px solid #0f171c;
-  padding: 2rem 2rem 1rem;
-  margin: 1.5rem 0;
-  display: flex;
   border-left: 3px solid var(--MAIN-ANCHOR-color);
 }
 

--- a/themes/docsy/layouts/shortcodes/checklist-item.html
+++ b/themes/docsy/layouts/shortcodes/checklist-item.html
@@ -1,10 +1,8 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="checklist-item">
-    <input type="checkbox">
-    <div>
-      <h4>{{ .Get "title" }}</h4>
-      <p>
-        {{ .Inner }}
-      </p>
-    </div>
+  <input type="checkbox" id="{{ .Get "title" }}">
+  <label for="{{ .Get "title" }}">
+    <h4>{{ .Get "title" }}</h4>
+  </label>
+  {{ .Inner }}
   </div>


### PR DESCRIPTION
This removes some overly-complicated layout and ensures that long
code blocks implement horizontal scrolling.

Fixes #570