### PR TITLE
Minor updates to the aside styling

### DIFF
--- a/themes/docsy/assets/scss/_custom.scss
+++ b/themes/docsy/assets/scss/_custom.scss
@@ -1014,19 +1014,16 @@ div.aside-tip > div.aside-title {
 }
 
 div.aside div.aside-title {
-  min-height: 30px;
   height: auto;
   display: flex;
   flex-direction: row;
-  /* To center the line vertically */
-  line-height: 30px;
   color: #fff;
   padding-left: 1em;
 }
 
 div.aside div.aside-title i {
   margin-right: 5px;
-  margin-top: 6px;
+  margin-top: 4px;
 }
 
 div.aside div.aside-content {


### PR DESCRIPTION
Here we remove the `line-height` rules, which were an attempt at vertical centering. This has the effect of limiting the empty space between lines in the event that an aside title does wrap onto multiple lines.