### PR TITLE
Remove unnecessary block quotes in kubernetes guides

### DIFF
--- a/content/guides/kubernetes/app-enhancements-graceful-shutdown.md
+++ b/content/guides/kubernetes/app-enhancements-graceful-shutdown.md
@@ -63,8 +63,10 @@ manually clean up the process.
 
 ![Graceful Shutdown Zombie](/images/guides/kubernetes/app-enhancements/graceful_shutdown_zombie.png)
 
-> While technically possible, it is unlikely you will end up with a zombie
-> process after forcefully deleting a pod.
+{{% aside title="Note" %}}
+While technically possible, it is unlikely you will end up with a zombie process
+after forcefully deleting a pod.
+{{% /aside %}}
 
 ## Shutting Down Gracefully
 

--- a/content/guides/kubernetes/harbor-as-docker-proxy.md
+++ b/content/guides/kubernetes/harbor-as-docker-proxy.md
@@ -17,9 +17,15 @@ team:
 {{< youtube id="KSH2Hzk-E7U" class="youtube-video-shortcode" >}}
 <div align="center"><i><a href="https://www.youtube.com/watch?v=KSH2Hzk-E7U&feature=youtu.be">Watch Paul Walk through this guide on Tanzu.TV Shortcuts.</a></i></div>
 
-On August 24 2020 [Docker](https://docker.com) announced they would be implementing [Rate Limits on the Docker Hub](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/) and they were [implemented on November 2 2020](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) thus ending our free ride of unlimited Docker Image pulls.
+On August 24 2020 [Docker](https://docker.com) announced they would be
+implementing
+[Rate Limits on the Docker Hub](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/)
+and they were
+[implemented on November 2 2020](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/)
+thus ending our free ride of unlimited Docker Image pulls.
 
-Unless you're a paid customer of Docker or very lucky you've probably started to see errors like this:
+Unless you're a paid customer of Docker or very lucky you've probably started to
+see errors like this:
 
 ```
 ERROR: toomanyrequests: Too Many Requests.
@@ -33,39 +39,65 @@ the limit by authenticating and upgrading:
 https://www.docker.com/increase-rate-limits.
 ```
 
-This can be very frustrating, especially in Kubernetes where it might not be apparent why your new Pod is just sitting there in a `Pending` state. Imagine this happening right as you need to scale your Deployments to serve a sudden increase in traffic.
+This can be very frustrating, especially in Kubernetes where it might not be
+apparent why your new Pod is just sitting there in a `Pending` state. Imagine
+this happening right as you need to scale your Deployments to serve a sudden
+increase in traffic.
 
-This would be where a troll on Reddit (You know the sort, the kind that will "[What you guys are referring to as Linux, is in fact, GNU/Linux"](https://news.ycombinator.com/item?id=6277943) at you would proclaim "[You own your availability](https://www.whoownsmyavailability.com/)". He's not wrong ... but also not helpful.
+This would be where a troll on Reddit (You know the sort, the kind that will
+"[What you guys are referring to as Linux, is in fact, GNU/Linux"](https://news.ycombinator.com/item?id=6277943)
+at you would proclaim
+"[You own your availability](https://www.whoownsmyavailability.com/)". He's not
+wrong ... but also not helpful.
 
 ![that twitter troll](/images/guides/kubernetes/harbor-as-docker-proxy/tweet-who-owns-your-availability.png)
 
-Thankfully the team developing the [Harbor Registry](https://goharbor.io/) have been hard at work to ensure that you can access the images you need without downloading the whole internet to your server.
+Thankfully the team developing the [Harbor Registry](https://goharbor.io/) have
+been hard at work to ensure that you can access the images you need without
+downloading the whole internet to your server.
 
-There are actually two features in Harbor that will let us work around the rate limits, Registry Replication, and Registry Proxy.
+There are actually two features in Harbor that will let us work around the rate
+limits, Registry Replication, and Registry Proxy.
 
-Registry Replication allows you to replicate images between registries, whereas Proxy lets you keep a local copy of images on an as-requested basis.
+Registry Replication allows you to replicate images between registries, whereas
+Proxy lets you keep a local copy of images on an as-requested basis.
 
-In a production scenario you would probably look to Replication so that you can be very specific about what Images to allow, however in a Development scenario you might use Proxy-ing as you don't necessarily know ahead of time what Images you might need access to. Further using Proxy-ing can be really useful for a home lab to cut down on internet traffic as you pull images.
+In a production scenario you would probably look to Replication so that you can
+be very specific about what Images to allow, however in a Development scenario
+you might use Proxy-ing as you don't necessarily know ahead of time what Images
+you might need access to. Further using Proxy-ing can be really useful for a
+home lab to cut down on internet traffic as you pull images.
 
 We'll explore both options below.
 
 ## Prerequisites
 
-Before you get started, you'll need Harbor (ideally version 2.1.3 or newer) installed somewhere. If you don't already have it installed, we've made it incredibly easy for your with our [Getting Started with Harbor](../harbor-gs/) Guide.
+Before you get started, you'll need Harbor (ideally version 2.1.3 or newer)
+installed somewhere. If you don't already have it installed, we've made it
+incredibly easy for your with our [Getting Started with Harbor](../harbor-gs/)
+Guide.
 
 Once you have a Harbor registry installed, log into it's Web UI as an Admin user.
 
-> Note: Docker has been rapidly changing both the Docker Hub and the Docker CLI, this makes it difficult for Integrations such as Harbor's replication / proxy features to keep pace. To ensure the best chance of functionality, ensure you're using the versions stated in this document.
+{{% aside type="info" title="Confirm Versions" %}}
+Note: Docker has been rapidly changing both the Docker Hub and the Docker CLI,
+this makes it difficult for Integrations such as Harbor's replication / proxy
+features to keep pace. To ensure the best chance of functionality, ensure you're
+using the versions stated in this document.
+{{% /aside %}}
 
 ## Set up a Registry Endpoint
 
-Whether doing replication or proxy, you need to configure Dockerhub as a replication endpoint.
+Whether doing replication or proxy, you need to configure Dockerhub as a
+replication endpoint.
 
 1. Go to **Administration** -> **Registries** and click the **+ New Endpoint** button.
 
 1. Set the **Provider** and **Name** both to `Docker Hub`.
 
-1. You can leave the rest of the settings as default, unless you want access to private images, in which case add in your **Access ID** and **Access Secret**.
+1. You can leave the rest of the settings as default, unless you want access to
+   private images, in which case add in your **Access ID** and **Access
+   Secret**.
 
 ![Create Endpoint](/images/guides/kubernetes/harbor-as-docker-proxy/create-endpoint.png)
 
@@ -73,7 +105,8 @@ Whether doing replication or proxy, you need to configure Dockerhub as a replica
 
 ## Create a Dockerhub Proxy
 
-> For more information about how Proxy Projects work, see the [official documentation](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/).
+For more information about how Proxy Projects work, see the
+[official documentation](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/).
 
 1. Go to **Projects** and click the **+ New Project** button.
 
@@ -85,11 +118,9 @@ Whether doing replication or proxy, you need to configure Dockerhub as a replica
 
 1. Set **Proxy Cache** to `Docker Hub` (the Endpoint we created earlier).
 
-![Create Proxy Project](/images/guides/kubernetes/harbor-as-docker-proxy/create-proxy-project.png)
+   ![Create Proxy Project](/images/guides/kubernetes/harbor-as-docker-proxy/create-proxy-project.png)
 
-1. Test the proxy is working:
-
-> If you receive error `Error response from daemon: missing or empty Content-Type header`, you'll need to upgrade Harbor to version 2.1.3 as some changes in Docker have had downstream ripple effects. Older versions of Docker will still work.
+1. Test the proxy is working with `docker pull`:  
 
 ```bash
 $ docker pull <url-of-registry>/dockerhub-proxy/library/ubuntu:20.04
@@ -102,13 +133,22 @@ Status: Downloaded newer image for harbor.aws.paulczar.wtf/dockerhub-proxy/libra
 harbor.aws.paulczar.wtf/dockerhub-proxy/library/ubuntu:20.04
 ```
 
+{{% aside type="warning" title="Content-Type Error" %}}
+If you receive error
+`Error response from daemon: missing or empty Content-Type header`, you'll need
+to upgrade Harbor to version 2.1.3 as some changes in Docker have had downstream
+ripple effects. Older versions of Docker will still work.
+{{% /aside %}}
+
 ## Configure Docker Hub Replication
 
 ### Create a Project to replicate to
 
-With Proxy-ing enabled, let's now turn our eyes to Replication. This is where we can surgically select which images we want to make available.
+With Proxy-ing enabled, let's now turn our eyes to Replication. This is where we
+can surgically select which images we want to make available.
 
-> For more information about how Replication works, see the [official documentation](https://goharbor.io/docs/2.1.0/administration/configuring-replication/).
+For more information about how Replication works, see the
+[official documentation](https://goharbor.io/docs/2.1.0/administration/configuring-replication/).
 
 1. Go to **Projects** and click the **+ New Project** button.
 
@@ -120,9 +160,13 @@ With Proxy-ing enabled, let's now turn our eyes to Replication. This is where we
 
 ### Create a Replication Rule
 
-Next we create a Replication Rule to determine the specific Images we want to replicate. In this case we want only the `library/python:3.8.2-slim` image. We restrict this as Replication can quickly hit the Docker Hub rate limits.
+Next we create a Replication Rule to determine the specific Images we want to
+replicate. In this case we want only the `library/python:3.8.2-slim` image. We
+restrict this as Replication can quickly hit the Docker Hub rate limits.
 
-> The resource filters support basic pattern recognition, so you could use `library/**` if you wanted to replicate all of the official images, however this would quickly hit the rate limits.
+The resource filters support basic pattern recognition, so you could use
+`library/**` if you wanted to replicate all of the official images, however this
+would quickly hit the rate limits.
 
 1. Go to **Administration** -> **Replication** and click the **+ New Replication Rule** button.
 
@@ -144,16 +188,28 @@ Next we create a Replication Rule to determine the specific Images we want to re
 
 ### Test Replication
 
-We chose manual replication (so that we don't overwhelm the rate limits) so we need to actually perform the replication step, and then validate that it worked.
+We chose manual replication (so that we don't overwhelm the rate limits) so we
+need to actually perform the replication step, and then validate that it worked.
 
-1. Go to **Administration** -> **Replication** and click the **dockerhub-python-slim** item then click the **Replicate** Button.
+1. Go to **Administration** -> **Replication** and click the
+   **dockerhub-python-slim** item then click the **Replicate** Button.
 
-Harbor will kick off the replication and will show the attempt below in the **Executions** section. You can click on it for more details or logs, but for now we're just waiting for it to **finish**.
+Harbor will kick off the replication and will show the attempt below in the
+**Executions** section. You can click on it for more details or logs, but for
+now we're just waiting for it to **finish**.
 
-1. Go to **Projects** and select **dockerhub-replica** then click **Repositories**. You should see `dockerhub-replica/python/python` with at least one Artifact. *To avoid this accidental redundancy in the name we should have set **Destination namespace** to `dockerhub-replica` rather than `dockerhub-replica/python`.
+1. Go to **Projects** and select **dockerhub-replica** then click
+   **Repositories**. You should see `dockerhub-replica/python/python` with at
+   least one Artifact. *To avoid this accidental redundancy in the name we
+   should have set **Destination namespace** to `dockerhub-replica` rather than
+   `dockerhub-replica/python`.
 
 ![Successful replication](/images/guides/kubernetes/harbor-as-docker-proxy/replica-success.png)
 
 ## Summary
 
-That's it!  We've learned how to replicate Docker images from Docker Hub using both Proxy-ing and Replication. This can be applied for Harbor to Harbor replication as well. It's not uncommon to have one main Harbor registry as the source of truth and then Replication to remote sites, and Proxy-ing to edge sites.
+That's it! We've learned how to replicate Docker images from Docker Hub using
+both Proxy-ing and Replication. This can be applied for Harbor to Harbor
+replication as well. It's not uncommon to have one main Harbor registry as the
+source of truth and then Replication to remote sites, and Proxy-ing to edge
+sites.

--- a/content/guides/kubernetes/harbor-gs.md
+++ b/content/guides/kubernetes/harbor-gs.md
@@ -15,41 +15,93 @@ team:
 - Paul Czarkowski
 ---
 
-Running a private container image registry has been a staple in many enterprise environments for years. These registries allow full control over access, updates, and the software platform itself. And while your organization may have an official image registry, having your own can also be a benefit!
+Running a private container image registry has been a staple in many enterprise
+environments for years. These registries allow full control over access,
+updates, and the software platform itself. And while your organization may have
+an official image registry, having your own can also be a benefit!
 
-Maybe it's just for learning. Or maybe you like the idea of self-hosting your own services. Or maybe, like so many companies that have also made the decision to self-host, you are concerned about security and access. Whatever the reason, you have made the decision to deploy your own. But this process includes a lot more than just an initial install.
+Maybe it's just for learning. Or maybe you like the idea of self-hosting your
+own services. Or maybe, like so many companies that have also made the decision
+to self-host, you are concerned about security and access. Whatever the reason,
+you have made the decision to deploy your own. But this process includes a lot
+more than just an initial install.
 
-A container image registry needs to be accessible to many online services to be useful, not the least of which is your desktop. It’s what makes pulling and pushing images possible. And you probably want it to be accessible from outside your own network, too, so that you can collaborate and share your projects. These days, to be secure, this requires TLS encryption to enable HTTPS traffic.
+A container image registry needs to be accessible to many online services to be
+useful, not the least of which is your desktop. It’s what makes pulling and
+pushing images possible. And you probably want it to be accessible from outside
+your own network, too, so that you can collaborate and share your projects.
+These days, to be secure, this requires TLS encryption to enable HTTPS traffic.
 
-In this guide, you will deploy Harbor to Kubernetes as the actual image registry application. You will also use Project Contour to manage ingress to your Kubernetes cluster.
+In this guide, you will deploy Harbor to Kubernetes as the actual image registry
+application. You will also use Project Contour to manage ingress to your
+Kubernetes cluster.
 
 {{< youtube id="SXSqrgYKO4s" class="youtube-video-shortcode" >}}
 
 ## Harbor and Contour
 
-[Harbor](https://goharbor.io) is a powerful registry for containers and Helm charts. It is fully open source and backed by the [Cloud Native Computing Foundation (CNCF)](https://landscape.cncf.io/selected=harbor). But getting it up and running, with automated TLS certificate renewal in particular, can be a challenge—especially with the multiple services Harbor uses that require east-west and north-south network communication.
+[Harbor](https://goharbor.io) is a powerful registry for containers and Helm
+charts. It is fully open source and backed by the
+[Cloud Native Computing Foundation (CNCF)](https://landscape.cncf.io/selected=harbor).
+But getting it up and running, with automated TLS certificate renewal in
+particular, can be a challenge—especially with the multiple services Harbor uses
+that require east-west and north-south network communication.
 
-[Contour](https://projectcontour.io), also a CNCF project, is an ingress controller built for Kubernetes. It functions as a control plane for Envoy while also offering advanced routing functionality beyond the default ingress controller provided by Kubernetes.
+[Contour](https://projectcontour.io), also a CNCF project, is an ingress
+controller built for Kubernetes. It functions as a control plane for Envoy while
+also offering advanced routing functionality beyond the default ingress
+controller provided by Kubernetes.
 
-You will deploy Harbor and Contour, and use [cert-manager](https://cert-manager.io/docs/) and [Let's Encrypt](https://letsencrypt.org) to automate TLS certificate generation and renewal for your Harbor installation. This will allow you to keep your Harbor installation up and running and utilizing HTTPS without manually generating and applying new certificates.
+You will deploy Harbor and Contour, and use
+[cert-manager](https://cert-manager.io/docs/) and
+[Let's Encrypt](https://letsencrypt.org) to automate TLS certificate generation
+and renewal for your Harbor installation. This will allow you to keep your
+Harbor installation up and running and utilizing HTTPS without manually
+generating and applying new certificates.
 
-Also, using the patterns in this guide, you should be able to deploy other services to Kubernetes and secure their ingress as well. And once you understand the basics of certificate management, ingress, and routing services, you’ll be able to keep on deploying other services to Kubernetes and enabling secure access over the internet!
+Also, using the patterns in this guide, you should be able to deploy other
+services to Kubernetes and secure their ingress as well. And once you understand
+the basics of certificate management, ingress, and routing services, you’ll be
+able to keep on deploying other services to Kubernetes and enabling secure
+access over the internet!
 
 ## Prerequisites
 
 Before you get started, you’ll need to do the following:
 
-- **Install Helm 3**: Helm is used in this guide to install Contour and Harbor. A guide for installing Helm can be found [here](https://helm.sh/docs/intro/install/).
+- **Install Helm 3**: Helm is used in this guide to install Contour and Harbor.
+  A guide for installing Helm can be found
+  [here](https://helm.sh/docs/intro/install/).
 
-- **Create a Kubernetes cluster**: This guide was built using Google Kubernetes Engine (GKE) with Kubernetes version 1.17. Any Kubernetes cluster with access to the internet should work fine, but your results may vary depending on the version you use. Initial testing with 1.16 resulted in errors during the Harbor install. For a guide on creating a GKE cluster, see [this page](https://cloud.google.com/kubernetes-engine/docs/quickstart) from Google. Ensure your [`kubectl` context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) is using this cluster.
+- **Create a Kubernetes cluster**: This guide was built using Google Kubernetes
+  Engine (GKE) with Kubernetes version 1.17. Any Kubernetes cluster with access
+  to the internet should work fine, but your results may vary depending on the
+  version you use. Initial testing with 1.16 resulted in errors during the
+  Harbor install. For a guide on creating a GKE cluster, see
+  [this page](https://cloud.google.com/kubernetes-engine/docs/quickstart) from
+  Google. Ensure your
+  [`kubectl` context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
+  is using this cluster.
 
-- **Install watch**: watch is a small command-line utility that continually shows the output of a command being run. This allows you to monitor `kubectl get pods`, for example, without explicitly re-running the command multiple times. Instructions for installing on macOS are [here](https://osxdaily.com/2010/08/22/install-watch-command-on-os-x/).
+- **Install watch**: watch is a small command-line utility that continually
+  shows the output of a command being run. This allows you to monitor
+  `kubectl get pods`, for example, without explicitly re-running the command
+  multiple times. Instructions for installing on macOS are
+  [here](https://osxdaily.com/2010/08/22/install-watch-command-on-os-x/).
 
-- **About 30 minutes**:  It could take more time than that; it will depend on how long the Let’s Encrypt servers take to issue certificates. But in most of my testing for writing this post, it took about 30 minutes.
+- **About 30 minutes**: It could take more time than that; it will depend on how
+  long the Let’s Encrypt servers take to issue certificates. But in most of my
+  testing for writing this post, it took about 30 minutes.
 
-- *Optional - buy a domain name*: You can use `.xip.io` (a [service](http://xip.io) that provides dynamic DNS based on IP address) addresses to avoid needing to buy a domain. Otherwise you will need a domain name that you control in order to configure DNS. This guide uses a Google-managed domain and DNS zone, but instructions can be modified for other providers.
-
-> Note: If you use `.xip.io` you may experience issues using the `letsencrypt-prod` ClusterIssuer later in the demo as it often hits the Lets Encrypt rate limits.  The first staging certificate step will work fine. If you hit the rate limit, often you can just wait a few hours and it'll eventually work. For best results use Google DNS with your own domain, or set up a wildcard DNS for your domain pointing at your Ingress IP.
+- *Optional - buy a domain name*: You can use `.xip.io` (a
+  [service](http://xip.io) that provides dynamic DNS based on IP address)
+  addresses to avoid needing to buy a domain. Otherwise you will need a domain
+  name that you control in order to configure DNS. This guide uses a
+  Google-managed domain and DNS zone, but instructions can be modified for other
+  providers. Note: if you do decide to use `.xip.io`, you may experience issues
+  using the `letsencrypt-prod` ClusterIssuer later in the demo due to rate
+  limiting. Often you can just wait a few hours and it'll eventually work. For
+  best results, we recommend using your own domain.
 
 ## Prepare the Environment
 
@@ -59,7 +111,8 @@ Create a Kubernetes cluster.  In GKE this can be as simple as running:
 gcloud container clusters create jan8 --num-nodes 3
 ```
 
-Being organized is key to any successful project. So before you dig in, create a new project directory and `cd` into it.
+Being organized is key to any successful project. So before you dig in, create a
+new project directory and `cd` into it.
 
 ```bash
 mkdir harbor-install && cd $_
@@ -67,12 +120,15 @@ mkdir harbor-install && cd $_
 
 ## Install Project Contour
 
-While you are going to use Helm to install Project Contour, Helm will not create the namespace for you. So the first step in this installation is to create that namespace.
+While you are going to use Helm to install Project Contour, Helm will not create
+the namespace for you. So the first step in this installation is to create that
+namespace.
 ```
 $ kubectl create namespace projectcontour
 ```
 
-If you do not have the Bitnami repo referenced in Helm yet (you can check by running `helm repo list`), you will need to install it.
+If you do not have the Bitnami repo referenced in Helm yet (you can check by
+running `helm repo list`), you will need to install it.
 
 ```
 helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -84,7 +140,10 @@ You will also need to update your Helm repositories.
 helm repo update
 ```
 
-Next, run `helm install` to finish the installation. Here you will install Bitnami's image for Contour. This chart includes defaults that will work out of the box for this guide. And since it comes from Bitnami, you can trust that the image has been thoroughly tested and scanned.
+Next, run `helm install` to finish the installation. Here you will install
+Bitnami's image for Contour. This chart includes defaults that will work out of
+the box for this guide. And since it comes from Bitnami, you can trust that the
+image has been thoroughly tested and scanned.
 
 ```
 helm install ingress bitnami/contour -n projectcontour --version 3.3.1
@@ -97,9 +156,16 @@ watch kubectl get pods -n projectcontour
 ```
 
 
-Then define some environment variables for your proposed Harbor domain and your email address. It is recommended that you use a subdomain under the domain procured in the prerequisites section (e.g., harbor.example.com). This way you can use other subdomain URLs to access other services you may deploy in the future. The email address will be used for your Let's Encrypt certificate so the cert authority can notify you about expirations.
+Then define some environment variables for your proposed Harbor domain and your
+email address. It is recommended that you use a subdomain under the domain
+procured in the prerequisites section (e.g., harbor.example.com). This way you
+can use other subdomain URLs to access other services you may deploy in the
+future. The email address will be used for your Let's Encrypt certificate so the
+cert authority can notify you about expirations.
 
-Defining these variables will make the rest of the commands in this guide more simple to run. The email address and the domain do not have to use the same domain (a Gmail address is fine).
+Defining these variables will make the rest of the commands in this guide more
+simple to run. The email address and the domain do not have to use the same
+domain (a Gmail address is fine).
 
 If you do not have a custom domain run:
 
@@ -124,11 +190,21 @@ export EMAIL_ADDRESS=username@example.com
 
 ## Set Up DNS
 
-> Skip this whole section if using `xip.io`.
+{{% aside type="warning" title="You may skip this section" %}}
+This section is not applicable for those using `xip.io`.
+If that's you, please skip this entire section.
+{{% /aside %}}
 
-**NOTE**: In this section, things can vary a bit. Because this guide was written using Google Cloud Platform (GCP) tooling, the instructions below will reflect that. But should you be using another provider, I will try to provide a generalized description of what is being done so you can look up those specific steps. I have also numbered these steps for clarity.
+In this section, things can vary a bit. Because this guide was written using
+Google Cloud Platform (GCP) tooling, the instructions below will reflect that.
+But should you be using another provider, I will try to provide a generalized
+description of what is being done so you can look up those specific steps. I
+have also numbered these steps for clarity.
 
-1. In order to set up DNS records, you need the IP address of the Envoy ingress router installed by Project Contour. Use the following command to describe the service. If the `EXTERNAL-IP` is still in a `<pending>` state, just wait until one is assigned. Record this value for a future step.
+1. In order to set up DNS records, you need the IP address of the Envoy ingress
+   router installed by Project Contour. Use the following command to describe
+   the service. If the `EXTERNAL-IP` is still in a `<pending>` state, just wait
+   until one is assigned. Record this value for a future step.
 
 ```bash
 watch kubectl get service ingress-contour-envoy -n projectcontour -o wide
@@ -136,27 +212,57 @@ watch kubectl get service ingress-contour-envoy -n projectcontour -o wide
 
 2. Now set up a DNS zone within your cloud provider.
 
-  - For GCP, this can be found in the GCP web UI, under Networking Services > Cloud DNS. Click `Create Zone` and follow the instructions to give the zone a descriptive name, as well as provide the DNS name. The DNS name will be whatever domain you have registered (e.g., `example.com`).
+  - For GCP, this can be found in the GCP web UI, under Networking Services,
+    Cloud DNS. Click `Create Zone` and follow the instructions to give the zone
+    a descriptive name, as well as provide the DNS name. The DNS name will be
+    whatever domain you have registered (e.g., `example.com`).
 
-  - For AWS, this is done via a service called [Route 53](https://aws.amazon.com/route53/faqs/), and for Azure, [this is done](https://docs.microsoft.com/en-us/azure/dns/dns-getstarted-portal_) by creating a resource in the Azure Portal.
+  - For AWS, this is done via a service called
+    [Route 53](https://aws.amazon.com/route53/faqs/), and for Azure,
+    [this is done](https://docs.microsoft.com/en-us/azure/dns/dns-getstarted-portal_)
+    by creating a resource in the Azure Portal.
 
-  - Once completed, the important part is that you now have a list of name servers. For example, one or more of the format `ns-cloud-x1.googledomains.com.` Record these for a future step.
+  - Once completed, the important part is that you now have a list of name
+    servers. For example, one or more of the format
+    `ns-cloud-x1.googledomains.com.` Record these for a future step.
 
-3. Next, add an A record to your DNS zone for a wildcard (`*`) subdomain. An A record is an "Address" record, one of the most fundamental types of DNS records; it maps the more user-friendly URL (harbor.example.com) to an IP address. Setting this up as a wildcard will allow you to configure any traffic coming into any subdomain to first be resolved by Project Contour and Envoy, then be routed to its final destination based on the specific subdomain requested.
+3. Next, add an A record to your DNS zone for a wildcard (`*`) subdomain. An A
+   record is an "Address" record, one of the most fundamental types of DNS
+   records; it maps the more user-friendly URL (harbor.example.com) to an IP
+   address. Setting this up as a wildcard will allow you to configure any
+   traffic coming into any subdomain to first be resolved by Project Contour and
+   Envoy, then be routed to its final destination based on the specific
+   subdomain requested.
 
-- For GCP, click into the DNS zone you just created and select `Add Record Set`. From here, add a `*` as the DNS name field so the full DNS name reads `*.example.com`. In the IPv4 address field, enter the `EXTERNAL_IP` of the Envoy service recorded earlier in Step 1. Then click create.
+- For GCP, click into the DNS zone you just created and select `Add Record Set`.
+  From here, add a `*` as the DNS name field so the full DNS name reads
+  `*.example.com`. In the IPv4 address field, enter the `EXTERNAL_IP` of the
+  Envoy service recorded earlier in Step 1. Then click create.
 
 - For AWS and Azure, this is done via the respective services listed in the previous step.
 
-- Once completed, your DNS zone should have an A record set up for any subdomain (`*`) to be mapped to the IP address of the Envoy service running in Kubernetes.
+- Once completed, your DNS zone should have an A record set up for any subdomain
+  (`*`) to be mapped to the IP address of the Envoy service running in
+  Kubernetes.
 
-4. For the last of the somewhat confusing UI-based steps, you need to add the list of name servers from Step 2 to your personal domain. This will allow any HTTP/HTTPS requests for your domain to reference the records you set up previously in your DNS zone.
+4. For the last of the somewhat confusing UI-based steps, you need to add the
+   list of name servers from Step 2 to your personal domain. This will allow any
+   HTTP/HTTPS requests for your domain to reference the records you set up
+   previously in your DNS zone.
 
-- For Google-managed domains, in the Google Domains UI, click `manage` next to the domain you want to modify. Then click on `DNS`. In the Name Servers section at the top, click `edit`. Now, one at a time, simply paste in the list of name servers recorded in Step 2. There should be four name server addresses. Then click `Save`.
+- For Google-managed domains, in the Google Domains UI, click `manage` next to
+  the domain you want to modify. Then click on `DNS`. In the Name Servers
+  section at the top, click `edit`. Now, one at a time, simply paste in the list
+  of name servers recorded in Step 2. There should be four name server
+  addresses. Then click `Save`.
 
-- For other domain name registrars, the process is similar. Contact your registrar if you require further assistance with this process.
+- For other domain name registrars, the process is similar. Contact your
+  registrar if you require further assistance with this process.
 
-That's it for configuring DNS. Now you need to wait for all the new records to propagate. Run the following command and wait for the output to show that your domain is now referencing the IP address of the Envoy service. This could take a few minutes.
+That's it for configuring DNS. Now you need to wait for all the new records to
+propagate. Run the following command and wait for the output to show that your
+domain is now referencing the IP address of the Envoy service. This could take a
+few minutes.
 
 ```bash
 watch host $DOMAIN
@@ -164,15 +270,23 @@ watch host $DOMAIN
 
 ## Install cert-manager
 
-[Cert-manager](https://cert-manager.io) will automate certificate renewal for your services behind Project Contour. When a certificate is set to expire, cert-manager will automatically request a new one from the certificate issuer (you will set this up in the next section). This is especially important when using a project like Let's Encrypt, whose certificates are only valid for 90 days.
+[Cert-manager](https://cert-manager.io) will automate certificate renewal for
+your services behind Project Contour. When a certificate is set to expire,
+cert-manager will automatically request a new one from the certificate issuer
+(you will set this up in the next section). This is especially important when
+using a project like Let's Encrypt, whose certificates are only valid for 90
+days.
 
-To install cert-manager, this guide uses Helm, for uniformity. As with installing Project Contour, Helm will not create a namespace, so the first step is to create one.
+To install cert-manager, this guide uses Helm, for uniformity. As with
+installing Project Contour, Helm will not create a namespace, so the first step
+is to create one.
 
 ```bash
 kubectl create namespace cert-manager
 ```
 
-If you do not have the Jetstack repo referenced in Helm yet (you can check by running `helm repo list`), you will need to install that reference.
+If you do not have the Jetstack repo referenced in Helm yet (you can check by
+running `helm repo list`), you will need to install that reference.
 
 ```bash
 helm repo add jetstack https://charts.jetstack.io
@@ -191,7 +305,8 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager \
    --version v1.0.2 --set installCRDs=true
 ```
 
-Finally, wait for the Pods to become `READY` before moving on to the next step. This should only take a minute or so.
+Finally, wait for the Pods to become `READY` before moving on to the next step.
+This should only take a minute or so.
 
 ```bash
 watch kubectl get pods -n cert-manager
@@ -199,13 +314,34 @@ watch kubectl get pods -n cert-manager
 
 ## Set up Let's Encrypt Staging Certificates
 
-When initially setting up your Harbor service, or any service that will be using Let's Encrypt, it is important to start by using certificates from their staging server as opposed to the production server. Staging certificates allow you to test your service without the risk of running up against any API rate limiting, which Let’s Encrypt imposes on its production environment. This is not a requirement, however; production certificates can be used initially. But using the staging ones is a good habit to get into, and will highlight how these certificates are applied.
+When initially setting up your Harbor service, or any service that will be using
+Let's Encrypt, it is important to start by using certificates from their staging
+server as opposed to the production server. Staging certificates allow you to
+test your service without the risk of running up against any API rate limiting,
+which Let’s Encrypt imposes on its production environment. This is not a
+requirement, however; production certificates can be used initially. But using
+the staging ones is a good habit to get into, and will highlight how these
+certificates are applied.
 
-Create the deployment YAML for the staging certificate by pasting the block below into a new file. Once applied, this will set up the staging cert configuration along with your email address, for certificate expirations notifications. You won't need to worry about these emails, however, as cert-manager will take care of the renewal for you.
+Create the deployment YAML for the staging certificate by pasting the block
+below into a new file. Once applied, this will set up the staging cert
+configuration along with your email address, for certificate expirations
+notifications. You won't need to worry about these emails, however, as
+cert-manager will take care of the renewal for you.
 
-Notice that this is of `kind: ClusterIssuer`. That means this certificate issuer is scoped to all namespaces in this Kubernetes cluster. For more granular controls in production, you may decide to simply change this to `kind: Issuer`, which will be scoped to a specific namespace and only allow services in that namespace to request certificates from that issuer. But be aware that this will necessitate changing other configuration options throughout this guide. We are using `ClusterIssuer` because it is secure enough for our use case, and presumably you are not using a multi-tenant Kubernetes cluster when following this guide.
+Notice that this is of `kind: ClusterIssuer`. That means this certificate issuer
+is scoped to all namespaces in this Kubernetes cluster. For more granular
+controls in production, you may decide to simply change this to `kind: Issuer`,
+which will be scoped to a specific namespace and only allow services in that
+namespace to request certificates from that issuer. But be aware that this will
+necessitate changing other configuration options throughout this guide. We are
+using `ClusterIssuer` because it is secure enough for our use case, and
+presumably you are not using a multi-tenant Kubernetes cluster when following
+this guide.
 
-Finally, this sets up a “challenge record" in the `solvers` section, which allows Let's Encrypt to verify that the certificate it is issuing is really controlled by you.
+Finally, this sets up a “challenge record" in the `solvers` section, which
+allows Let's Encrypt to verify that the certificate it is issuing is really
+controlled by you.
 
 ```bash
 cat << EOF > letsencrypt-staging.yaml
@@ -232,7 +368,9 @@ Now `apply` the file.
 kubectl apply -f letsencrypt-staging.yaml
 ```
 
-The process of creating the cluster issuer should be fairly quick, but you can confirm it completed successfully by running the following and ensuring the cluster issuer was issued.
+The process of creating the cluster issuer should be fairly quick, but you can
+confirm it completed successfully by running the following and ensuring the
+cluster issuer was issued.
 
 ```bash
 $ kubectl get clusterissuers.cert-manager.io
@@ -242,19 +380,35 @@ letsencrypt-staging   True    74s
 
 ## Install Harbor
 
-Now that you have your staging certificate, you can install Harbor, for which this guide uses Helm in combination with the Bitnami repo set up earlier. As with your other install steps, the first thing to do is create the namespace.
+Now that you have your staging certificate, you can install Harbor, for which
+this guide uses Helm in combination with the Bitnami repo set up earlier. As
+with your other install steps, the first thing to do is create the namespace.
 
 ```
 kubectl create namespace harbor
 ```
 
-Next, create the values file. The Bitnami Helm chart includes defaults that, for the most part, will work for your needs. However, there are a few configuration options that need to be set.
+Next, create the values file. The Bitnami Helm chart includes defaults that, for
+the most part, will work for your needs. However, there are a few configuration
+options that need to be set.
 
-Here you will notice that you are giving the TLS secret in Kubernetes a name, `harbor-tls-staging`. You can choose any name you like, but it should be descriptive and reflect that this secret will be distinct from the production certificate you will apply later.
+Here you will notice that you are giving the TLS secret in Kubernetes a name,
+`harbor-tls-staging`. You can choose any name you like, but it should be
+descriptive and reflect that this secret will be distinct from the production
+certificate you will apply later.
 
-You are also setting up references to your domain so Harbor and Contour can set up routing. The Annotations section is important as it tells Harbor about our configuration. Notice that for `cert-manager.io/cluster-issuer: letsencrypt-staging` you are telling Harbor to use the `ClusterIssuer` called letsencrypt-staging, the one you set up earlier. This will come up again later when you move to production certificates. Comments are provided in the file for further detail.
+You are also setting up references to your domain so Harbor and Contour can set
+up routing. The Annotations section is important as it tells Harbor about our
+configuration. Notice that for
+`cert-manager.io/cluster-issuer: letsencrypt-staging` you are telling Harbor to
+use the `ClusterIssuer` called letsencrypt-staging, the one you set up earlier.
+This will come up again later when you move to production certificates. Comments
+are provided in the file for further detail.
 
-Finally, this values file will disable the Harbor Notary service. At the time of this writing there is a bug in the Bitnami Helm chart (already reported) that doesn't allow a TLS certificate to be applied for both `notary.$DOMAIN` and `registry.$DOMAIN`. I will try to update this post once that bug is fixed.
+Finally, this values file will disable the Harbor Notary service. At the time of
+this writing there is a bug in the Bitnami Helm chart (already reported) that
+doesn't allow a TLS certificate to be applied for both `notary.$DOMAIN` and
+`registry.$DOMAIN`. I will try to update this post once that bug is fixed.
 
 ```bash
 cat << EOF > harbor-values.yaml
@@ -297,7 +451,9 @@ And wait for the Pods to become `<READY>`. This may take a minute or two.
 watch kubectl get pods -n harbor
 ```
 
-Finally, ensure that the certificates were requested and returned successfully. This should happen fairly quickly, but may take up to an hour. It all depends on the server load at that time.
+Finally, ensure that the certificates were requested and returned successfully.
+This should happen fairly quickly, but may take up to an hour. It all depends on
+the server load at that time.
 
 ```bash
 $ kubectl -n harbor get certificate
@@ -316,15 +472,24 @@ password: $(kubectl get secret --namespace harbor harbor-core-envvars -o jsonpat
 EOF
 ```
 
-Now open your browser of choice and go to your URL. You will notice that you will need to accept the security warning that the site is "untrusted." This is because you are still using the staging certificates, which are not signed by a trusted certificate authority (CA).
+Now open your browser of choice and go to your URL. You will notice that you
+will need to accept the security warning that the site is "untrusted." This is
+because you are still using the staging certificates, which are not signed by a
+trusted certificate authority (CA).
 
-Once you ensure that you can log in and that Harbor is working as intended, you can move to production certificates.
+Once you ensure that you can log in and that Harbor is working as intended, you
+can move to production certificates.
 
 ## Set Up Let's Encrypt Production Certificates
 
-> Reminder, if using `.xip.io` you may encounter rate limit issues with Lets Encrypt causing major delays in the certificate issuance.
+{{% aside type="warning" title="Rate Limits" %}}
+Reminder, if using `.xip.io` you may encounter rate limit issues with Lets
+Encrypt causing major delays in the certificate issuance.
+{{% /aside %}}
 
-Similar to how you set up the Let's Encrypt staging certificate, you now need to create the `ClusterIssuer` for production certificates. First, `echo` the following to create the file.
+Similar to how you set up the Let's Encrypt staging certificate, you now need to
+create the `ClusterIssuer` for production certificates. First, `echo` the
+following to create the file.
 
 ```bash
 cat << EOF > letsencrypt-prod.yaml
@@ -351,13 +516,19 @@ Then apply it to your Kubernetes cluster.
 kubectl apply -f letsencrypt-prod.yaml
 ```
 
-Again, you can confirm this process completed successfully by running the following and ensuring the cluster issuer was issued.
+Again, you can confirm this process completed successfully by running the
+following and ensuring the cluster issuer was issued.
 
 ```bash
 kubectl get clusterissuers
 ```
 
-Recall how earlier in the annotations of the Harbor `values.yml` file you told Harbor to use the `letsencrypt-staging` cluster issuer, as well as the secret `harbor-tls-staging`. You must now tell Harbor to use the production cluster issuer you just created, and trigger it to create a new secret based on that certificate. To do this, you are going to update the `harbor-values.yaml` file using `sed`:
+Recall how earlier in the annotations of the Harbor `values.yml` file you told
+Harbor to use the `letsencrypt-staging` cluster issuer, as well as the secret
+`harbor-tls-staging`. You must now tell Harbor to use the production cluster
+issuer you just created, and trigger it to create a new secret based on that
+certificate. To do this, you are going to update the `harbor-values.yaml` file
+using `sed`:
 
 ```
 sed -i 's/-staging/-prod/' harbor-values.yaml
@@ -365,31 +536,37 @@ sed -i 's/-staging/-prod/' harbor-values.yaml
 
 Run `helm delete` then `helm install` to uninstall and reinstall Harbor:
 
-> Note: The persistent volumes are not deleted during the `helm delete` so any changes in Harbor you may have made should persist.
+Note: The persistent volumes are not deleted during the `helm delete` so any
+changes in Harbor you may have made should persist.
 
 ```bash
 helm delete -n harbor harbor
 helm install harbor bitnami/harbor -f harbor-values.yaml -n harbor --version 9.4.4
 ```
 
-wait for the new Pods to become `<READY>`. This may take a minute or two.
+Wait for the new Pods to become `<READY>`. This may take a minute or two.
 
 ```bash
 watch kubectl get pods -n harbor
 ```
 
-
-This process may take as little as a minute or as long as an hour. It just depends on the server load at that time. But in most of my testing, it took less than 10 minutes.
+This process may take as little as a minute or as long as an hour. It just
+depends on the server load at that time. But in most of my testing, it took less
+than 10 minutes.
 
 ```bash
 watch kubectl get certificate harbor-tls-prod -n harbor
 ```
 
-Once the certificates are generated successfully, your Harbor instance should be up and running with valid and trusted TLS certificates. Try logging into Harbor again.
+Once the certificates are generated successfully, your Harbor instance should be
+up and running with valid and trusted TLS certificates. Try logging into Harbor
+again.
 
-Your browser should no longer present a warning, as the certificate you are now using is signed by a trusted CA.
+Your browser should no longer present a warning, as the certificate you are now
+using is signed by a trusted CA.
 
-> Note: If you still see certificate warnings, you may need to re-open it from a fresh browser.
+Note: If you still see certificate warnings, you may need to re-open it from a
+fresh browser.
 
 ## Test Harbor
 
@@ -431,4 +608,8 @@ replicaset.apps/nginx-7cdffc88cf   1         1         1       5s
 
 ## Summary
 
-That's it! You now have a service running in Kubernetes with TLS encryption enforced and certificate generation automated. And by using these patterns, you should be able to install and configure other services as well. Specific steps, especially around the configuration of the service itself, will be different, but after using this guide you should have a leg up in getting started.
+That's it! You now have a service running in Kubernetes with TLS encryption
+enforced and certificate generation automated. And by using these patterns, you
+should be able to install and configure other services as well. Specific steps,
+especially around the configuration of the service itself, will be different,
+but after using this guide you should have a leg up in getting started.

--- a/content/guides/kubernetes/kubeapps-gs.md
+++ b/content/guides/kubernetes/kubeapps-gs.md
@@ -12,19 +12,35 @@ team:
 - Tiffany Jernigan
 ---
 
-> This getting started guide is a copy of [Get Started with Kubeapps](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md) in the [kubeapps/kubeapps repository](https://github.com/kubeapps/kubeapps) inclusive of commit [1e49264](https://github.com/kubeapps/kubeapps/commit/1e49264088094dfd327d2a24b62cda470cc547d0) on April 20, 2020.
-
 This guide will walk you through the process of deploying Kubeapps for your cluster and installing an example application.
+
+{{% aside title="Note" %}}
+This getting started guide is a copy of
+[Get Started with Kubeapps](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md)
+in the [kubeapps/kubeapps repository](https://github.com/kubeapps/kubeapps)
+inclusive of commit
+[1e49264](https://github.com/kubeapps/kubeapps/commit/1e49264088094dfd327d2a24b62cda470cc547d0)
+on April 20, 2020.
+{{% /aside %}}
+
+This guide is also available in video form:
 
 {{< youtube 9HsWsoDd1fM >}}
 
 ## Prerequisites
 
-Kubeapps assumes a working Kubernetes cluster (v1.8+), [`Helm`](https://helm.sh/) (2.14.0+) installed in your cluster and [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed and configured to talk to your Kubernetes cluster. Kubeapps has been tested with Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), `minikube` and Docker for Desktop Kubernetes. Kubeapps works on RBAC-enabled clusters and this configuration is encouraged for a more secure install.
+Kubeapps assumes a working Kubernetes cluster (v1.8+),
+[`Helm`](https://helm.sh/) (2.14.0+) installed in your cluster and
+[`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed
+and configured to talk to your Kubernetes cluster. Kubeapps has been tested with
+Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), `minikube` and
+Docker for Desktop Kubernetes. Kubeapps works on RBAC-enabled clusters and this
+configuration is encouraged for a more secure install.
 
-> On GKE, you must either be an "Owner" or have the "Container Engine Admin" role in order to install Kubeapps.
-
-
+{{% aside title="GKE Permissions" %}}
+On GKE, you must either be an "Owner" or have the "Container Engine Admin" role
+in order to install Kubeapps.
+{{% /aside %}}
 
 ## Step 1: Install Kubeapps
 
@@ -45,20 +61,28 @@ kubectl create namespace kubeapps
 helm install kubeapps --namespace kubeapps bitnami/kubeapps --set useHelm3=true
 ```
 
-For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/kubeapps/kubeapps/blob/master/chart/kubeapps/README.md).
+For detailed information on installing, configuring and upgrading Kubeapps,
+checkout the
+[chart README](https://github.com/kubeapps/kubeapps/blob/master/chart/kubeapps/README.md).
 
-The above commands will deploy Kubeapps into the `kubeapps` namespace in your cluster. It may take a few minutes to execute. Once it has been deployed and the Kubeapps pods are running, continue to step 2.
+The above commands will deploy Kubeapps into the `kubeapps` namespace in your
+cluster. It may take a few minutes to execute. Once it has been deployed and the
+Kubeapps pods are running, continue to step 2.
 
 ## Step 2: Create a Kubernetes API token
 
-Access to the Dashboard requires a Kubernetes API token to authenticate with the Kubernetes API server.
+Access to the Dashboard requires a Kubernetes API token to authenticate with the
+Kubernetes API server.
 
 ```bash
 kubectl create serviceaccount kubeapps-operator
 kubectl create clusterrolebinding kubeapps-operator --clusterrole=cluster-admin --serviceaccount=default:kubeapps-operator
 ```
 
-> **NOTE** It's not recommended to create `cluster-admin` users for Kubeapps production usage. Please refer to the [Access Control](https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md) documentation to configure fine-grained access control for users.
+**NOTE:** It's not recommended to create `cluster-admin` users for Kubeapps
+production usage. Please refer to the
+[Access Control](https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md)
+documentation to configure fine-grained access control for users.
 
 To retrieve the token,
 
@@ -87,31 +111,43 @@ DEL token.txt
 certutil -decode b64.txt token.txt
 ```
 
-Open a command prompt and run the `GetDashToken.cmd` Your token can be found in the `token.txt` file.
+Open a command prompt and run the `GetDashToken.cmd` Your token can be found in
+the `token.txt` file.
 
 ## Step 3: Start the Kubeapps Dashboard
 
-Once Kubeapps is installed, securely access the Kubeapps Dashboard from your system by running:
+Once Kubeapps is installed, securely access the Kubeapps Dashboard from your
+system by running:
 
 ```bash
 kubectl port-forward -n kubeapps svc/kubeapps 8080:80
 ```
 
-This will start an HTTP proxy for secure access to the Kubeapps Dashboard. Visit http://127.0.0.1:8080/ in your preferred web browser to open the Dashboard. Here's what you should see:
+This will start an HTTP proxy for secure access to the Kubeapps Dashboard. Visit
+http://127.0.0.1:8080/ in your preferred web browser to open the Dashboard.
+Here's what you should see:
 
 ![Dashboard login page](/images/guides/kubernetes/kubeapps/screenshots/dashboard-login.png)
 
-Paste the token generated in the previous step to authenticate and access the Kubeapps dashboard for Kubernetes.
+Paste the token generated in the previous step to authenticate and access the
+Kubeapps dashboard for Kubernetes.
 
 ![Dashboard main page](/images/guides/kubernetes/kubeapps/screenshots/dashboard-home.png)
 
-***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/kubeapps/kubeapps/blob/master/chart/kubeapps/README.md).
+***Note:*** If you are setting up Kubeapps for other people to access, you will
+want to use a different service type or setup Ingress rather than using the
+above `kubectl port-forward`. For detailed information on installing,
+configuring and upgrading Kubeapps, checkout the
+[chart README](https://github.com/kubeapps/kubeapps/blob/master/chart/kubeapps/README.md).
 
 ## Step 4: Deploy WordPress
 
-Once you have the Kubeapps Dashboard up and running, you can start deploying applications into your cluster.
+Once you have the Kubeapps Dashboard up and running, you can start deploying
+applications into your cluster.
 
-- Use the "Deploy App" or click on the "Catalog" page in the Dashboard to select an application from the list of charts in any of the configured Helm chart repositories. This example assumes you want to deploy WordPress.
+- Use the "Deploy App" or click on the "Catalog" page in the Dashboard to select
+  an application from the list of charts in any of the configured Helm chart
+  repositories. This example assumes you want to deploy WordPress.
 
   ![WordPress chart](/images/guides/kubernetes/kubeapps/screenshots/wordpress-search.png)
 
@@ -119,26 +155,44 @@ Once you have the Kubeapps Dashboard up and running, you can start deploying app
 
   ![WordPress chart](/images/guides/kubernetes/kubeapps/screenshots/wordpress-chart.png)
 
-- You will be prompted for the release name and values for the application. The form is populated by the values (YAML), which you can see in the adjacent tab.
+- You will be prompted for the release name and values for the application. The
+  form is populated by the values (YAML), which you can see in the adjacent tab.
 
   ![WordPress installation](/images/guides/kubernetes/kubeapps/screenshots/wordpress-installation.png)
 
-- Click the "Submit" button. The application will be deployed. You will be able to track the new Helm deployment directly from the browser. The status will be shown at the top and you can also look at the individual resources lower in the page. It will also show the number of ready pods. If you run your cursor over the status, you can see the workloads and number of ready and total pods within them.
+- Click the "Submit" button. The application will be deployed. You will be able
+  to track the new Helm deployment directly from the browser. The status will be
+  shown at the top and you can also look at the individual resources lower in
+  the page. It will also show the number of ready pods. If you run your cursor
+  over the status, you can see the workloads and number of ready and total pods
+  within them.
 
   ![WordPress deployment](/images/guides/kubernetes/kubeapps/screenshots/wordpress-deployment.png)
 
-To access your new WordPress site, you can run the commands in the "Notes" section to get the URLs or simply click a URL (HTTP and HTTPS) shown.
+To access your new WordPress site, you can run the commands in the "Notes"
+section to get the URLs or simply click a URL (HTTP and HTTPS) shown.
 
-***Note:*** Depending on your cloud provider of choice, it may take some time for an access URL to be available for the application and the Service will stay in a "Pending" state until a URL is assigned. If using Minikube, you will need to run `minikube tunnel` in your terminal in order for an IP address to be assigned to your application.
+***Note:*** Depending on your cloud provider of choice, it may take some time
+for an access URL to be available for the application and the Service will stay
+in a "Pending" state until a URL is assigned. If using Minikube, you will need
+to run `minikube tunnel` in your terminal in order for an IP address to be
+assigned to your application.
 
 ![WordPress deployment notes](/images/guides/kubernetes/kubeapps/screenshots/wordpress-url.png)
 
-To get the credentials for logging into your WordPress account, refer to the "Notes" section. You can also get the WordPress password by scrolling down to "Secrets" and clicking the eye next to `wordpress-password`.
+To get the credentials for logging into your WordPress account, refer to the
+"Notes" section. You can also get the WordPress password by scrolling down to
+"Secrets" and clicking the eye next to `wordpress-password`.
 
 ![WordPress deployment notes](/images/guides/kubernetes/kubeapps/screenshots/wordpress-credentials.png)
 
 ## [Optional] Step 5: Uninstall/Delete WordPress
-If you want to uninstall/delete your WordPress application, you can do so by clicking the "Delete" button. You can choose to click the checkbox for "Purge Release" (default action with the Helm 3 CLI). If you do not click it, the Helm chart history will remain (default action with Helm 2). This is fine, so long as you don't attempt to install another chart with the same name in the same namespace.
+If you want to uninstall/delete your WordPress application, you can do so by
+clicking the "Delete" button. You can choose to click the checkbox for "Purge
+Release" (default action with the Helm 3 CLI). If you do not click it, the Helm
+chart history will remain (default action with Helm 2). This is fine, so long as
+you don't attempt to install another chart with the same name in the same
+namespace.
 
 ![WordPress uninstall](/images/guides/kubernetes/kubeapps/screenshots/wordpress-uninstall.png)
 

--- a/content/guides/kubernetes/kubeapps-private-repo.md
+++ b/content/guides/kubernetes/kubeapps-private-repo.md
@@ -17,7 +17,15 @@ team:
 - Raquel Campuzano
 ---
 
-[Kubeapps](https://github.com/kubeapps/kubeapps/) is a web-based UI for deploying and managing applications in Kubernetes clusters. Kubeapps includes a built-in catalog of Helm charts and operators continuously maintained and up to date. Now Kubeapps also provides support for private Helm repositories with private Docker images. There is an option of associating Docker credentials to an application repository so that Kubeapps can ensure they are used to pull any matching private images within a chart. This option is really useful for enterprise development team since it allows them to have more granular access control as well as a known good source of images. 
+[Kubeapps](https://github.com/kubeapps/kubeapps/) is a web-based UI for
+deploying and managing applications in Kubernetes clusters. Kubeapps includes a
+built-in catalog of Helm charts and operators continuously maintained and up to
+date. Now Kubeapps also provides support for private Helm repositories with
+private Docker images. There is an option of associating Docker credentials to
+an application repository so that Kubeapps can ensure they are used to pull any
+matching private images within a chart. This option is really useful for
+enterprise development team since it allows them to have more granular access
+control as well as a known good source of images.
 
 Kubeapps officially supports the following Helm repositories:
 
@@ -25,7 +33,9 @@ Kubeapps officially supports the following Helm repositories:
 * [Harbor](https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#harbor)
 * [Artifactory Pro](https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#artifactory)
 
-This tutorial shows you how to create a private project in Harbor, push a customized Helm chart to your registry and create an application repository to have your chart ready from the Kubeapps UI to be deployed. 
+This tutorial shows you how to create a private project in Harbor, push a
+customized Helm chart to your registry and create an application repository to
+have your chart ready from the Kubeapps UI to be deployed.
 
 Watch the following video or keep reading this tutorial to learn more:
 
@@ -35,12 +45,20 @@ Watch the following video or keep reading this tutorial to learn more:
 
 This guide assumes that:
 
-* You have a Docker environment installed and configured. Learn more about [installing Docker](https://docs.docker.com/engine/install/).
-* You have a Docker Hub account. [Register for a free account](https://hub.docker.com/).
-* You have a Kubernetes cluster. Check out our [Getting Started with Kubernetes guides](https://docs.bitnami.com/kubernetes/) for an easy way to get started with one.
-* You have administrator access to a preexisting installation of [Harbor](https://github.com/bitnami/charts/tree/master/bitnami/harbor).
-* You have [Helm installed in your cluster](https://docs.bitnami.com/kubernetes/get-started-kubernetes/#step-4-install-helm). 
-* You have [Kubeapps installed in your cluster](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md) and are logged into the Kubeapps UI with admin credentials. 
+* You have a Docker environment installed and configured. Learn more about
+  [installing Docker](https://docs.docker.com/engine/install/).
+* You have a Docker Hub account.
+  [Register for a free account](https://hub.docker.com/).
+* You have a Kubernetes cluster. Check out our
+  [Getting Started with Kubernetes guides](https://docs.bitnami.com/kubernetes/)
+  for an easy way to get started with one.
+* You have administrator access to a preexisting installation of
+  [Harbor](https://github.com/bitnami/charts/tree/master/bitnami/harbor).
+* You have
+  [Helm installed in your cluster](https://docs.bitnami.com/kubernetes/get-started-kubernetes/#step-4-install-helm).
+* You have
+  [Kubeapps installed in your cluster](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md)
+  and are logged into the Kubeapps UI with admin credentials.
 
 ## Step 1: Create a private project in Harbor
 
@@ -48,13 +66,17 @@ The first step is to create a project in Harbor. To do so:
 
 * Log in to Harbor.
 * In the "Projects" section, click "+ New Project".
-* In the resulting screen, give a name to your project. This should be private so don't activate the "Public" check. To get an unlimited storage quota, set that value as -1. Click "OK" to proceed.
+* In the resulting screen, give a name to your project. This should be private
+  so don't activate the "Public" check. To get an unlimited storage quota, set
+  that value as -1. Click "OK" to proceed.
 
   ![Create a private project in Harbor](/images/guides/kubernetes/kubeapps-private-repo/harbor-create-new-project.png)
 
 ## Step 2: Pull the Docker image and push it to your private Harbor Registry
 
-Next, pull the Docker image of the chart you want to add to your private repository. Then, you need to push it to Harbor to make it available in your project. Follow these steps:
+Next, pull the Docker image of the chart you want to add to your private
+repository. Then, you need to push it to Harbor to make it available in your
+project. Follow these steps:
 
 * Execute the following command to obtain the latest Bitnami Ghost image: 
 
@@ -62,7 +84,8 @@ Next, pull the Docker image of the chart you want to add to your private reposit
   docker pull bitnami/ghost:3.13.2-debian-10-r0
   ```
 
-* Tag the image by executing the command below. Remember to replace the HARBOR_DOMAIN_NAME placeholder with the domain name where Harbor is installed. 
+* Tag the image by executing the command below. Remember to replace the
+  `HARBOR_DOMAIN_NAME` placeholder with the domain name where Harbor is installed.
 
   ```bash
   docker tag docker.io/bitnami/ghost:3.13.2-debian-10-r0 HARBOR_DOMAIN_NAME/project-private/ghost:3.13.2-debian-10-r0
@@ -99,16 +122,23 @@ Next, pull the Docker image of the chart you want to add to your private reposit
   3.13.2-debian-10-r0: digest: sha256:9121f532fbe28f8e6d4cb11bf542374689c4595378ef83adeda5bff46731d972 size: 2839
   ```
 
-* Navigate to the Harbor UI and in your project, select the tab "Repositories". You should see the repository that contains the image you just pushed. Click on it to check image details: 
+* Navigate to the Harbor UI and in your project, select the tab "Repositories".
+  You should see the repository that contains the image you just pushed. Click
+  on it to check image details:
 
  ![Harbor repositories](/images/guides/kubernetes/kubeapps-private-repo/harbor-images-pushed.png)
 
 ## Step 3: Enable a Robot Account in your project
 
-Next step is to enable a Robot Account in your project with access to pull both Helm charts from the private repositories as well as Docker images in the private project. To do so:
+Next step is to enable a Robot Account in your project with access to pull both
+Helm charts from the private repositories as well as Docker images in the
+private project. To do so:
 
-* From the Harbor UI, navigate to the "Robot Account" tab in your project and click "+ New Robot Account". 
-* In the resulting window, give it a name, a description (optional) and in the "Permissions" section, activate the "Pull" check in the Helm Chart line. Click "Save" to proceed.
+* From the Harbor UI, navigate to the "Robot Account" tab in your project and
+  click "+ New Robot Account".
+* In the resulting window, give it a name, a description (optional) and in the
+  "Permissions" section, activate the "Pull" check in the Helm Chart line. Click
+  "Save" to proceed.
 
   ![Create a Robot Account in your project](/images/guides/kubernetes/kubeapps-private-repo/create-robot-account.png)
 
@@ -118,13 +148,16 @@ Once it is created, remember to copy the token in a safe place or export it to f
 
 ## Step 4: Customize your Helm chart and push it to your private Harbor Registry
 
-* Get the Bitnami Ghost Helm chart and change to the chart's directory by executing the following command:
+* Get the Bitnami Ghost Helm chart and change to the chart's directory by
+  executing the following command:
 
   ```bash
   helm fetch bitnami/ghost --untar && cd ghost
   ```
 
-* Edit the *values.yaml* file of the chart of the chart so that the image.registry and image.repository value point to your registry and repository path respectively:
+* Edit the *values.yaml* file of the chart of the chart so that the
+  image.registry and image.repository value point to your registry and
+  repository path respectively:
 
   ![Modify the chart values.yaml file](/images/guides/kubernetes/kubeapps-private-repo/chart-values-yaml.png)
 
@@ -134,9 +167,11 @@ Once it is created, remember to copy the token in a safe place or export it to f
   cd ../ && helm package ./ghost
   ```
 
-  You will see an output message similar to this: "Successfully packaged chart". 
+  You will see an output message similar to this: "Successfully packaged chart".
 
-* From the Harbor UI, navigate to the "Helm Charts" tab and click "Upload". Browse the resultant *tgz* file of your packaged chart and click "Upload". You will see your Helm Chart uploaded in a few minutes:
+* From the Harbor UI, navigate to the "Helm Charts" tab and click "Upload".
+  Browse the resultant *tgz* file of your packaged chart and click "Upload". You
+  will see your Helm Chart uploaded in a few minutes:
 
   ![Harbor Helm chart uploaded](/images/guides/kubernetes/kubeapps-private-repo/harbor-helm-chart.png)
 
@@ -144,19 +179,29 @@ Once it is created, remember to copy the token in a safe place or export it to f
 
   ![Harbor Helm chart details](/images/guides/kubernetes/kubeapps-private-repo/harbor-chart-details.png)
 
-Now that you have both the Ghost image and its Helm chart available in your Harbor private repository, it is time to create an application repository in Kubeapps to start deploying your charts on Kubernetes from its dashboard.
+Now that you have both the Ghost image and its Helm chart available in your
+Harbor private repository, it is time to create an application repository in
+Kubeapps to start deploying your charts on Kubernetes from its dashboard.
 
 ## Step 5: Create an application repository to enable your Harbor's private repository in Kubeapps
 
 * Log in to Kubeapps.
-* Select the namespace where the repository (and the secret) are to be created. This should be different from the *kubeapps* namespace.
-* From the menu button in the top right corner, select the "App Repositories" option, then click the "Add App Repository" button.
+* Select the namespace where the repository (and the secret) are to be created.
+  This should be different from the *kubeapps* namespace.
+* From the menu button in the top right corner, select the "App Repositories"
+  option, then click the "Add App Repository" button.
 * In the resulting screen enter the following information:
 
   * Application repository name
   * URL: private repository URL
-  * Repository Authorization: select the "Basic Auth" option and enter as "Username" the name you gave to the Robot Account created in Harbor, and as "Password", the token you obtain at the time of the creation. This way, Kubeapps will be able to see the charts you have pulled into your Harbor repository.
-  * Associate Docker Registry Credentials: click "Add New Credentials" to add the credentials that will allow Kubernetes to pull images from your private repository. Add the values below, then click "Submit" 
+  * Repository Authorization: select the "Basic Auth" option and enter as
+    "Username" the name you gave to the Robot Account created in Harbor, and as
+    "Password", the token you obtain at the time of the creation. This way,
+    Kubeapps will be able to see the charts you have pulled into your Harbor
+    repository.
+  * Associate Docker Registry Credentials: click "Add New Credentials" to add
+    the credentials that will allow Kubernetes to pull images from your private
+    repository. Add the values below, then click "Submit"
    
     * Secret name
     * Server: Harbor's server domain
@@ -165,38 +210,61 @@ Now that you have both the Ghost image and its Helm chart available in your Harb
 
   ![Add an application repository with the Harbor credentials](/images/guides/kubernetes/kubeapps-private-repo/app-repo-pull-secret.png)
 
-* Click the "Install Repo" button to finish the process. You will see your new application repository in the list of existing application repositories in your namespace. 
+* Click the "Install Repo" button to finish the process. You will see your new
+  application repository in the list of existing application repositories in
+  your namespace.
 
   ![List of application repositories](/images/guides/kubernetes/kubeapps-private-repo/app-repositories.png)
 
-  If you click the repository link, you will be redirected to its catalog. You should see your Ghost chart there ready to be deployed: 
+  If you click the repository link, you will be redirected to its catalog. You
+  should see your Ghost chart there ready to be deployed:
 
   ![Private repository application catalog](/images/guides/kubernetes/kubeapps-private-repo/private-repo-catalog.png)
 
 ## Step 6: Deploy your custom Ghost from the Kubeapps UI
     
-Finally, you are able to install your custom application from your private registry on Kubernetes using the Kubeapps UI. 
+Finally, you are able to install your custom application from your private
+registry on Kubernetes using the Kubeapps UI.
 
-* In the application repository catalog you just created, click the Ghost entry to go to the chart page.
-* On the resulting screen, you can learn about the Ghost chart, the repository where it is located, review older versions, and any related links. Click "Deploy" to deploy the chart:
+* In the application repository catalog you just created, click the Ghost entry
+  to go to the chart page.
+* On the resulting screen, you can learn about the Ghost chart, the repository
+  where it is located, review older versions, and any related links. Click
+  "Deploy" to deploy the chart:
 
   ![Deploy Ghost from your private repository](/images/guides/kubernetes/kubeapps-private-repo/deploy-ghost.png)
 
-* This will take you to a page where you can configure your Ghost deployment. You can use either the "Form" or the "YAML" tab to customize your deployment as you want: give your chart a name, change the version you want to deploy, add an admin password (if not, a random 10-character alphanumeric string will be set), or configure Helm values. 
+* This will take you to a page where you can configure your Ghost deployment.
+  You can use either the "Form" or the "YAML" tab to customize your deployment
+  as you want: give your chart a name, change the version you want to deploy,
+  add an admin password (if not, a random 10-character alphanumeric string will
+  be set), or configure Helm values.
 
-  > IMPORTANT: The Ghost chart requires a resolvable host. Specify it in the "Hostname" section. 
+  {{% aside type="info" title="Important" %}}
+  The Ghost chart requires a resolvable host. Specify it in the "Hostname" section. 
+  {{% /aside %}}
 
   ![Ghost values](/images/guides/kubernetes/kubeapps-private-repo/ghost-values-kubeapps.png)
 
-* Click "Submit" to start the application deployment. Once submitted, you will be redirected to a page that describes the state of your deployment. The status will be "Deploying" until Ghost is up and running.
+* Click "Submit" to start the application deployment. Once submitted, you will
+  be redirected to a page that describes the state of your deployment. The
+  status will be "Deploying" until Ghost is up and running.
 
   ![Ghost deployment](/images/guides/kubernetes/kubeapps-private-repo/ghost-deployment.png)
 
-* Once the chart is deployed, you can see all the deployment details, including the URLs to access the application. 
+* Once the chart is deployed, you can see all the deployment details, including
+  the URLs to access the application.
 
-  By default, Ghost creates a Service with LoadBalancer type to provide an externally accessible URL for its web interface. Depending on your cloud provider of choice, the load balancer can take some time to provision and will stay in a "Pending" state until it is available. If using Minikube, you will need to run minikube tunnel in a new terminal window in order for an IP address to be assigned.
+  By default, Ghost creates a Service with LoadBalancer type to provide an
+  externally accessible URL for its web interface. Depending on your cloud
+  provider of choice, the load balancer can take some time to provision and will
+  stay in a "Pending" state until it is available. If using Minikube, you will
+  need to run minikube tunnel in a new terminal window in order for an IP
+  address to be assigned.
 
- After some time, the URL should be visible in the Access URL table. Once it is visible, click one of the URLs shown to access your freshly deployed Ghost blog.
+ After some time, the URL should be visible in the Access URL table. Once it is
+ visible, click one of the URLs shown to access your freshly deployed Ghost
+ blog.
 
  ![Ghost home page](/images/guides/kubernetes/kubeapps-private-repo/ghost.png)
 

--- a/content/guides/kubernetes/service-routing-contour-to-ingress-and-beyond.md
+++ b/content/guides/kubernetes/service-routing-contour-to-ingress-and-beyond.md
@@ -21,11 +21,22 @@ team:
 
 ### Introduction to Contour
 
-[Contour](https://projectcontour.io/) is an open source Kubernetes [Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) that acts as a control plane for the Envoy edge and service proxy (see below).​ Contour supports dynamic configuration updates and multi-team ingress delegation while maintaining a lightweight profile.
+[Contour](https://projectcontour.io/) is an open source Kubernetes
+[Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)
+that acts as a control plane for the Envoy edge and service proxy (see below).​
+Contour supports dynamic configuration updates and multi-team ingress delegation
+while maintaining a lightweight profile.
 
-Contour is built for Kubernetes to empower you to quickly deploy cloud native applications by using the flexible HTTPProxy API which is a lightweight system that provides many of the advanced routing features of a Service Mesh.
+Contour is built for Kubernetes to empower you to quickly deploy cloud native
+applications by using the flexible HTTPProxy API which is a lightweight system
+that provides many of the advanced routing features of a Service Mesh.
 
-Contour deploys the [Envoy](https://www.envoyproxy.io/docs/envoy/latest/intro/what_is_envoy) proxy as a reverse proxy and load balancer.  Envoy is a Layer 7 (application layer) bus for proxy and communication in modern service-oriented architectures, such as Kubernetes clusters. Envoy strives to make the network transparent to applications while maximizing observability to ease troubleshooting.
+Contour deploys the
+[Envoy](https://www.envoyproxy.io/docs/envoy/latest/intro/what_is_envoy) proxy
+as a reverse proxy and load balancer. Envoy is a Layer 7 (application layer) bus
+for proxy and communication in modern service-oriented architectures, such as
+Kubernetes clusters. Envoy strives to make the network transparent to
+applications while maximizing observability to ease troubleshooting.
 
 {{< youtube id="Kz671dXioS0" class="youtube-video-shortcode" >}}
 <div align="center"><i><a href="https://www.youtube.com/watch?v=Kz671dXioS0&feature=youtu.be">Watch Paul livestream trying Contour 1.12.0 for the first time.</a></i></div>
@@ -33,7 +44,13 @@ Contour deploys the [Envoy](https://www.envoyproxy.io/docs/envoy/latest/intro/wh
 
 ### Before You Begin
 
-You'll need a Kubernetes cluster. This guide uses a [Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid) cluster, but any Kubernetes Cluster whether they're running on a Public Cloud, in your [Home] Lab, or on your desktop such as [KIND](https://kind.sigs.k8s.io/) or [minikube](https://minikube.sigs.k8s.io/docs/start/). You'll also need the Kubernetes CLI [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+You'll need a Kubernetes cluster. This guide uses a
+[Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid) cluster, but
+any Kubernetes Cluster whether they're running on a Public Cloud, in your
+[Home] Lab, or on your desktop such as [KIND](https://kind.sigs.k8s.io/) or
+[minikube](https://minikube.sigs.k8s.io/docs/start/). You'll also need the
+Kubernetes CLI
+[kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 1. Verify access to your Kubernetes cluster
 
@@ -52,9 +69,15 @@ You'll need a Kubernetes cluster. This guide uses a [Tanzu Kubernetes Grid](http
 
 ### Installing Contour 1.12.0
 
-Since version 1.11.0 we've got two primary options for installing Contour, A singleton install from manifests, or by using the [Operator](https://projectcontour.io/resources/deprecation-policy/) (which is currently in Alpha). Since we only plan to install Contour once on the cluster, we can stick to the safer method of using the Contour provided manifests.
+Since version 1.11.0 we've got two primary options for installing Contour, A
+singleton install from manifests, or by using the
+[Operator](https://projectcontour.io/resources/deprecation-policy/) (which is
+currently in Alpha). Since we only plan to install Contour once on the cluster,
+we can stick to the safer method of using the Contour provided manifests.
 
-You can install Contour directly from the manifests provided by the project, however best practice would have you download them locally first for validation and repeatability.
+You can install Contour directly from the manifests provided by the project,
+however best practice would have you download them locally first for validation
+and repeatability.
 
 1. Download contour installation manifests
     ```bash
@@ -81,7 +104,9 @@ You can install Contour directly from the manifests provided by the project, how
 
 1. After a few moments you can confirm that its ready.
 
-    > You're looking for both the **deployment** and **DaemonSet** to show as fully Available, and a valid IP (or hostname) in the `EXTERNAL-IP` field of your envoy **service**.
+    You're looking for both the **deployment** and **DaemonSet** to show as fully
+    Available, and a valid IP (or hostname) in the `EXTERNAL-IP` field of your
+    envoy **service**.
 
     ```bash
     $ kubectl -n projectcontour get deployment,daemonset,service
@@ -99,17 +124,24 @@ You can install Contour directly from the manifests provided by the project, how
       service/envoy     LoadBalancer   100.66.114.136   a36c85343e9284c1cb4236d844c31aab-1691151764.us-east-2.elb.amazonaws.com   80:30825/TCP,443:30515/TCP   2m18s
     ```
 
-    1. Save the Ingress `EXTERNAL-IP` for later use as a [xip.io](http://xip.io) dynamic DNS host.
+  1. Save the Ingress `EXTERNAL-IP` for later use as a [xip.io](http://xip.io) dynamic DNS host.
 
-    > Note: Since this is deployed in Amazon Web Services I had to resolve the hostname using the `host` command, but in other clouds you will probably get an IP address.
+  {{% aside title="Note for AWS Users" %}}
+  Since this is deployed in Amazon Web Services I had to resolve the hostname
+  using the `host` command, but in other clouds you will probably get an IP
+  address.
+  {{% /aside %}}
 
-    ```bash
-    INGRESS_HOST=<external ip address from above>.xip.io
-    ```
+  ```bash
+  INGRESS_HOST=<external ip address from above>.xip.io
+  ```
 
 ### Creating an Ingress using Contour 1.12.0
 
-Now that Contour is installed we can validate it is functioning correctly by deploying an application, exposing it as a service, then creating an Ingress resource. As well as creating the resources we'll output the manifests to a file for later re-use.
+Now that Contour is installed we can validate it is functioning correctly by
+deploying an application, exposing it as a service, then creating an Ingress
+resource. As well as creating the resources we'll output the manifests to a file
+for later re-use.
 
 1. Create a namespace
 
@@ -167,11 +199,21 @@ Now that Contour is installed we can validate it is functioning correctly by dep
     <h1>Welcome to nginx!</h1>
     ```
 
-Congratulations! If you see the **Welcome to nginx!** message, that means you've successfully installed and tested Contour as an Ingress Controller. However its so much more than that, so lets explore further.
+Congratulations! If you see the **Welcome to nginx!** message, that means you've
+successfully installed and tested Contour as an Ingress Controller. However its
+so much more than that, so lets explore further.
 
-However let's clean up our resources before we move on. Since all of our resources are in a single namespace we could use `kubectl delete namespace my-ingress-app`, However we also saved the manifests so we can use those like so:
+However let's clean up our resources before we move on. Since all of our
+resources are in a single namespace we could use
+`kubectl delete namespace my-ingress-app`, However we also saved the manifests
+so we can use those like so:
 
-> Note: we created these manifests in the same path as our contour manifests, so we will move them into a subdirectory to ensure we only delete the app itself. This is a lesson learned that we should have created them in a sub directory in the first place for organizational purposes.
+{{% aside title="Caution" type="warning" %}}
+We created these manifests in the same directory as our contour manifests, so
+we will move them into a subdirectory to ensure we only delete the app itself.
+This is a lesson learned that we should have created them in a subdirectory
+in the first place for organizational purposes.
+{{% /aside %}}
 
 ```bash
 mkdir my-ingress-app
@@ -181,9 +223,13 @@ kubectl delete -f my-ingress-app
 
 ### Beyond Ingress with Contour 1.12.0
 
-As well as **Ingress** Contour supports a resource type **HTTPProxy** which extends the concept of **Ingress** to add many features that you would normally have to reach for **Istio** or a similar service mesh to get. We can explore some of those features here.
+As well as **Ingress** Contour supports a resource type **HTTPProxy** which
+extends the concept of **Ingress** to add many features that you would normally
+have to reach for **Istio** or a similar service mesh to get. We can explore
+some of those features here.
 
-Having learned our lesson about sub directories above, lets create a directory for our exploration of HTTPProxy.
+Having learned our lesson about sub directories above, lets create a directory
+for our exploration of HTTPProxy.
 
 ```bash
 mkdir http-proxy
@@ -212,7 +258,9 @@ As we did earlier we'll start by deploying a nginx **Pod** and a **Service**.
       > http-proxy-nginx-service.yaml
     ```
 
-Now that we have the Deployment and Service created we can create the HTTPProxy resource. Unfortunately we can't just sling a `kubectl create httpproxy` like we could with the other resources so we'll need to get creative.
+Now that we have the Deployment and Service created we can create the HTTPProxy
+resource. Unfortunately we can't just sling a `kubectl create httpproxy` like we
+could with the other resources so we'll need to get creative.
 
 1. Create a HTTPProxy manifest
 
@@ -250,9 +298,17 @@ Now that we have the Deployment and Service created we can create the HTTPProxy 
 
 #### Rate Limiting
 
-Now that your nginx is working via **HTTPProxy** we can look at some of the more advanced features. Let's start with Rate limiting. Contour 1.12.0 supports doing *local* rate limiting, which means that each Envoy **Pod** will have its own limits, vs a *global* rate limit which would need further coordination between the Envoy **Pods**. You can also set the Rate limit for the virtualhost, or for a specific route.
+Now that your nginx is working via **HTTPProxy** we can look at some of the more
+advanced features. Let's start with Rate limiting. Contour 1.12.0 supports doing
+*local* rate limiting, which means that each Envoy **Pod** will have its own
+limits, vs a *global* rate limit which would need further coordination between
+the Envoy **Pods**. You can also set the Rate limit for the virtualhost, or for
+a specific route.
 
-Let's create a fairly aggressive rate limit so we can see the affects of it fairly quickly. The example cluster I am using has three worker nodes, which means three Envoy **Pods** so if I set a rate limit of 2 per minute we should be able to hit the limit after 6 requests.
+Let's create a fairly aggressive rate limit so we can see the affects of it
+fairly quickly. The example cluster I am using has three worker nodes, which
+means three Envoy **Pods** so if I set a rate limit of 2 per minute we should be
+able to hit the limit after 6 requests.
 
 1. Create a new **HTTPProxy** resource with rate limiting enabled
 
@@ -285,9 +341,10 @@ Let's create a fairly aggressive rate limit so we can see the affects of it fair
     kubectl -n http-proxy apply -f rate-limit.yaml
     ```
 
-1. Wait a few moments and then fire up a while loop to connecting to the service and watch it hit the limit after a few hits.
+1. Wait a few moments and then fire up a while loop to connecting to the service
+   and watch it hit the limit after a few hits.
 
-    > Note: You'll need to hit CTRL-C to break the while loop.
+   Note: You'll need to hit CTRL-C to break the while loop.
 
     ```bash
     $ while true; do curl -s rate.$INGRESS_HOST | grep -E 'h1|rate' ; done
@@ -304,11 +361,17 @@ Let's create a fairly aggressive rate limit so we can see the affects of it fair
     ^C
     ```
 
-That's it, rate limiting is enabled. This is incredibly useful if you have a service with known limitations or you want to restrict any one user from overwhelming the service.
+That's it, rate limiting is enabled. This is incredibly useful if you have a
+service with known limitations or you want to restrict any one user from
+overwhelming the service.
 
 #### Weighted routing
 
-The **HTTPProxy** resource can also route a Virtual Host to multiple services, this is a great feature if you want to perform Blue/Green deployments, or you want to send a small percentage of requests to a special debug endpoint. Let's explore Weighted routing by adding an Apache service to receive 10% of the requests.
+The **HTTPProxy** resource can also route a Virtual Host to multiple services,
+this is a great feature if you want to perform Blue/Green deployments, or you
+want to send a small percentage of requests to a special debug endpoint. Let's
+explore Weighted routing by adding an Apache service to receive 10% of the
+requests.
 
 1. Create a Deployment containing a basic httpd pod
 
@@ -366,7 +429,9 @@ The **HTTPProxy** resource can also route a Virtual Host to multiple services, t
 
 1. Test the weighting
 
-    > Note: It's not clear in the documentation, but it appears that the weighting is applied per Envoy **Pod** so it might not be exactly 10% for small test runs, but would statistically work out over time.
+   Note: It's not clear in the documentation, but it appears that the weighting
+   is applied per Envoy **Pod**, so it might not be exactly 10% for small test
+   runs, but would statistically work out over time.
 
     ```bash
     $ while true; do curl -s weight.$INGRESS_HOST | grep h1 ; done
@@ -387,7 +452,11 @@ The **HTTPProxy** resource can also route a Virtual Host to multiple services, t
     ^C
     ```
 
-That's it! we've successfully done a walk through of some of the new features of Contour 1.12.0 and tested out both Rate Limiting and Weighted Routing. Let's clean up.
+That's it! we've successfully done a walk through of some of the new features of
+Contour 1.12.0 and tested out both Rate Limiting and Weighted Routing. Let's
+clean up.
+
+#### Cleanup
 
 1. Delete your http-proxy namespace and resources
 
@@ -404,4 +473,7 @@ That's it! we've successfully done a walk through of some of the new features of
 
 ### Conclusion
 
-As you can see Contour 1.12.0 is more than just an Ingress Controller as it brings some of the more advanced features of a service mesh but without all the extra resources required. Next time you find yourself looking to run Istio, remember to check in with Contour and see if it will do what you need.
+As you can see Contour 1.12.0 is more than just an Ingress Controller as it
+brings some of the more advanced features of a service mesh but without all the
+extra resources required. Next time you find yourself looking to run Istio,
+remember to check in with Contour and see if it will do what you need.

--- a/content/guides/kubernetes/velero-gs.md
+++ b/content/guides/kubernetes/velero-gs.md
@@ -12,38 +12,83 @@ team:
 - Tiffany Jernigan
 ---
 
-What do you do if you lose state in your cluster, or something went very wrong and you need to revert it or move my resources to another cluster? Are you out of luck?
+What do you do if you lose state in your cluster, or something went very wrong
+and you need to revert it or move my resources to another cluster? Are you out
+of luck?
 
-That’s where [Velero](https://velero.io/) comes in. Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes. This guide will show you how to deploy Velero to your Kubernetes cluster, create backups, and recover from a backup after something goes wrong in the cluster.
+That’s where [Velero](https://velero.io/) comes in. Velero is an open source
+tool to safely backup and restore, perform disaster recovery, and migrate
+Kubernetes cluster resources and persistent volumes. This guide will show you
+how to deploy Velero to your Kubernetes cluster, create backups, and recover
+from a backup after something goes wrong in the cluster.
 
 ## Prerequisites
+
 Before you get started you will need to do the following:
-* **Create a Kubernetes cluster**: You need a Kubernetes cluster, v1.10 or later, with DNS and container networking enabled. This guide uses a Google Kubernetes Engine (GKE) Linux cluster with Kubernetes version 1.16.5 and Velero 1.5.3. As of the writing of this guide, Velero [does not officially support Windows](https://velero.io/docs/v1.5/basic-install/#velero-on-windows).
-* **Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on our local machine**: You probably already have that one if you're working with Kubernetes.installed locally
-* **Verify the cluster has a [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/)**: Check if you have a storage class with `kubectl get storageclasses`. You need one to create persistent volumes.
-* **Install the `velero` CLI**: There are a few [options](https://velero.io/docs/v1.5/basic-install/#install-the-cli) to install Velero. This guide uses `brew install velero` and `velero` v1.5.3 . [Enabling shell autocompletion](https://velero.io/docs/v1.5/customize-installation/#enabling-shell-autocompletion) can be very helpful too. 
+
+* **Create a Kubernetes cluster**: You need a Kubernetes cluster, v1.10 or
+  later, with DNS and container networking enabled. This guide uses a Google
+  Kubernetes Engine (GKE) Linux cluster with Kubernetes version 1.16.5 and
+  Velero 1.5.3. As of the writing of this guide, Velero
+  [does not officially support Windows](https://velero.io/docs/v1.5/basic-install/#velero-on-windows).
+* **Install
+  [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on our
+  local machine**: You probably already have that one if you're working with
+  Kubernetes.installed locally
+* **Verify the cluster has a
+  [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/)**:
+  Check if you have a storage class with `kubectl get storageclasses`. You need
+  one to create persistent volumes.
+* **Install the `velero` CLI**: There are a few
+  [options](https://velero.io/docs/v1.5/basic-install/#install-the-cli) to
+  install Velero. This guide uses `brew install velero` and `velero` v1.5.3 .
+  [Enabling shell autocompletion](https://velero.io/docs/v1.5/customize-installation/#enabling-shell-autocompletion)
+  can be very helpful too.
 
 You can also look at the [Velero Basic Install documentation](https://velero.io/docs/v1.5/basic-install/).
 
 ## Setup
-Now that you have your Kubernetes cluster and the Velero CLI installed, we can move to the next step.
 
-First you need to **install Velero server components** in your cluster. To do this, you need a **storage provider** for Velero to store your resources and volumes. In this guide, since we use GKE, we will use Google Cloud Storage as the object store. If you're deploying Velero in a different environment, check the [providers documentation](https://velero.io/docs/v1.5/supported-providers/) for specific setup instructions. 
+Now that you have your Kubernetes cluster and the Velero CLI installed, we can
+move to the next step.
 
-You can either use the `velero install` CLI command with the required storage provider flags or the [Velero Helm chart](https://vmware-tanzu.github.io/helm-charts/). We will use the CLI in this guide.
+First you need to **install Velero server components** in your cluster. To do
+this, you need a **storage provider** for Velero to store your resources and
+volumes. In this guide, since we use GKE, we will use Google Cloud Storage as
+the object store. If you're deploying Velero in a different environment, check
+the [providers documentation](https://velero.io/docs/v1.5/supported-providers/)
+for specific setup instructions.
+
+You can either use the `velero install` CLI command with the required storage
+provider flags or the
+[Velero Helm chart](https://vmware-tanzu.github.io/helm-charts/). We will use
+the CLI in this guide.
 
 ### Initial Setup
-There are quite a few different storage provider options such as vSphere, AWS, and GCP. 
-This guide uses the [setup for GCP](https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup). 
+
+There are quite a few different storage provider options such as vSphere, AWS,
+and GCP. This guide uses the
+[setup for GCP](https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup).
+
+{{% aside title="Note for GKE Users" %}}
+If you run Google Kubernetes Engine (GKE), make sure that your current IAM
+user is a cluster-admin. This role is required to create RBAC objects. See
+the
+[GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap)
+for more information.
+{{% /aside %}}
 
 1.  First we need to create an object storage bucket for Velero to save backups in:
     ```
     BUCKET=<your-bucket-name>
     gsutil mb gs://$BUCKET/
     ```
-    > If you run Google Kubernetes Engine (GKE), make sure that your current IAM user is a cluster-admin. This role is required to create RBAC objects. See the [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap) for more information.
 
-With GCP you can set Velero permissions [using a service account](https://github.com/vmware-tanzu/velero-plugin-for-gcp#option-2-set-permissions-with-using-workload-identity-optional) or optionally [using Workload Identity](https://github.com/vmware-tanzu/velero-plugin-for-gcp#option-2-set-permissions-with-using-workload-identity-optional) to set up Velero GCP permissions. This guide will use a service account.
+    With GCP you can set Velero permissions
+    [using a service account](https://github.com/vmware-tanzu/velero-plugin-for-gcp#option-2-set-permissions-with-using-workload-identity-optional)
+    or optionally
+    [using Workload Identity](https://github.com/vmware-tanzu/velero-plugin-for-gcp#option-2-set-permissions-with-using-workload-identity-optional)
+    to set up Velero GCP permissions. This guide will use a service account.
 
 2. Get the current GCP project:
     ```bash
@@ -56,7 +101,9 @@ With GCP you can set Velero permissions [using a service account](https://github
     gcloud iam service-accounts create velero \
         --display-name "Velero service account"
     ```
-    > Note: If you'll be using Velero to back up multiple clusters with multiple GCS buckets, you may want to create a unique name per cluster instead of just `velero`.
+    Tip: If you'll be using Velero to back up multiple clusters with multiple
+    GCS buckets, you may want to create a unique name per cluster instead of
+    just `velero`.
 
 4. Set `SERVICE_ACCOUNT_EMAIL` to the email attached to your new service account:
     ```bash
@@ -98,7 +145,10 @@ With GCP you can set Velero permissions [using a service account](https://github
     ```
 
 ### Install Velero
-OK, now it’s time to install Velero. We need to give `velero install` the provider, provider plugin, storage bucket, and IAM credentials.
+
+OK, now it’s time to install Velero. We need to give `velero install` the
+provider, provider plugin, storage bucket, and IAM credentials.
+
 ```bash
 velero install \
     --provider gcp \
@@ -107,18 +157,34 @@ velero install \
     --secret-file ./credentials-velero
 ```
 
-It will then display the resources that are being created. If you’re interested in looking further, you can view Velero's server-side components by running:
+It will then display the resources that are being created. If you’re interested
+in looking further, you can view Velero's server-side components by running:
+
 ```bash
 kubectl -n velero get all
 ```
 
-Velero also uses a number of CRDs (Custom Resource Definitions) to represents its own resources like backups, backups schedules, etc.
+Velero also uses a number of CRDs (Custom Resource Definitions) to represents
+its own resources like backups, backups schedules, etc.
 
 ## Run Apps
-As an example, we will deploy an instance of Ghost. Ghost is a personal blog, similar to WordPress. We will be using the [Ghost Helm Chart](https://bitnami.com/stack/ghost/helm). 
 
-1. Create a file containing configuration values for the Ghost Helm Chart. Ghost uses MariaDB for storage. For simplicity, we are going to hard-code in that file the database credentials, as well as the login credentials (so that we know these passwords). The `ghostPassword` and `ghostEmail` will be used to log into the admin account to create blogs.
-    > Note: These are sample, insecure passwords. Please don’t use these outside of a demo! Instead of a values YAML file, we could also use multiple `--set` flags when invoking `helm install` below.
+As an example, we will deploy an instance of Ghost. Ghost is a personal blog,
+similar to WordPress. We will be using the
+[Ghost Helm Chart](https://bitnami.com/stack/ghost/helm).
+
+1. Create a file containing configuration values for the Ghost Helm Chart. Ghost
+   uses MariaDB for storage. For simplicity, we are going to hard-code in that
+   file the database credentials, as well as the login credentials (so that we
+   know these passwords). The `ghostPassword` and `ghostEmail` will be used to
+   log into the admin account to create blogs. 
+   
+   {{% aside type="warning" title="Caution" %}}
+   These are sample, insecure passwords. Please don’t use these outside of
+   a demo! Instead of a values YAML file, we could also use multiple `--set`
+   flags when invoking `helm install` below.
+   {{% /aside %}}
+   
     ```bash
     # Create a file called ghost-values.yaml in the current dir
     # And add the following variables
@@ -144,7 +210,11 @@ As an example, we will deploy an instance of Ghost. Ghost is a personal blog, si
 3. Create the `ghost` namespace and install the Helm chart.
 
     For Helm 3:
-    > Note: As of Helm 3.2.0 you can add a `--create-namespace` flag to the `helm` command instead of using kubectl to create the namespace first.
+
+    {{% aside title="Tip for Helm 3.2.0 and later" %}}
+As of Helm 3.2.0 you can add a `--create-namespace` flag to the `helm`
+command instead of using kubectl to create the namespace first.
+    {{% /aside %}}
 
     ```bash
     kubectl create namespace ghost
@@ -154,7 +224,8 @@ As an example, we will deploy an instance of Ghost. Ghost is a personal blog, si
         --values ./ghost-values.yaml 
     ```
 
-    You should see an error message telling you that you "did not provide an external host"; so we're going to address that.
+    You should see an error message telling you that you "did not provide an
+    external host"; so we're going to address that.
 
 4. Check if the load balancer is up and running. It should have an `EXTERNAL_IP` listed.
     ```bash
@@ -170,7 +241,8 @@ As an example, we will deploy an instance of Ghost. Ghost is a personal blog, si
     ghost-mariadb   ClusterIP      10.108.8.42    <none>          3306/TCP       2m2s
     ```
 
-5. Once it’s running, get the load balancer’s external IP and add it to our ghost-values.yaml and upgrade the Helm chart to get the deployment to start:
+5. Once it’s running, get the load balancer’s external IP and add it to our
+   ghost-values.yaml and upgrade the Helm chart to get the deployment to start:
     ```bash
     # Set the APP_HOST to the ghost service's EXTERNAL-IP. You could also copy-paste
     export APP_HOST=$(kubectl get svc --namespace ghost ghost \--template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
@@ -186,9 +258,13 @@ As an example, we will deploy an instance of Ghost. Ghost is a personal blog, si
         --values ./ghost-values.yaml
     ```
 
-6. Helm will show us our blog URL, and the admin URL that we will use in a minute to create some content. The IP address is the `EXTERNAL_IP` of the load balancer.
+6. Helm will show us our blog URL, and the admin URL that we will use in a
+   minute to create some content. The IP address is the `EXTERNAL_IP` of the
+   load balancer.
 
-    So right now you should be seeing these resources. Your IP addresses will be different; and if the pods are not both `Running` and `READY` yet, give them a minute to come up.
+    So right now you should be seeing these resources. Your IP addresses will be
+    different; and if the pods are not both `Running` and `READY` yet, give them
+    a minute to come up.
 
     ```bash
     kubectl -n ghost get all
@@ -211,19 +287,30 @@ As an example, we will deploy an instance of Ghost. Ghost is a personal blog, si
     statefulset.apps/ghost-mariadb   1/1     50m
     ```
 
-7. Now open your `Admin URL` in a web browser. If it doesn't load, double-check that the pods shown in the previous section show up as `1/1` in the `READY` column. Sign in the admin interface with the email and password that we entered earlier in the values file. You should now see the following screen, which will let us create a blog:
+7. Now open your `Admin URL` in a web browser. If it doesn't load, double-check
+   that the pods shown in the previous section show up as `1/1` in the `READY`
+   column. Sign in the admin interface with the email and password that we
+   entered earlier in the values file. You should now see the following screen,
+   which will let us create a blog:
    ![Ghost Admin Page](/images/guides/kubernetes/velero-gs/1-welcome-to-ghost.png)
 
-   Click on the `+` next to Posts to create your first post. Enter a title and some content, then click Publish in the top right.
+   Click on the `+` next to Posts to create your first post. Enter a title and
+   some content, then click Publish in the top right.
    ![Ghost Publish Page](/images/guides/kubernetes/velero-gs/2-ghost-create-post.png)
 
    The home page should now look like this:
    ![Ghost Page With Post](/images/guides/kubernetes/velero-gs/3-ghost-home-page.png)
 
 ## Backup
-Now, let’s look into backups in case something happens to the blog. Backups are for Kubernetes resources and persistent volumes. You can back up your entire cluster, or optionally choose a namespace or label selector to back up. 
 
-They can be run one off or scheduled. It’s a good idea to have scheduled backups so you are certain you have a recent backup to easily fall back to. You can also create [backup hooks](https://velero.io/docs/v1.5/backup-hooks/) if you want to execute actions before or after a backup is made.
+Now, let’s look into backups in case something happens to the blog. Backups are
+for Kubernetes resources and persistent volumes. You can back up your entire
+cluster, or optionally choose a namespace or label selector to back up.
+
+They can be run one off or scheduled. It’s a good idea to have scheduled backups
+so you are certain you have a recent backup to easily fall back to. You can also
+create [backup hooks](https://velero.io/docs/v1.5/backup-hooks/) if you want to
+execute actions before or after a backup is made.
 
 By default, the backup retention is 30 days, but you can change it with the `--ttl` flag.
 
@@ -232,13 +319,18 @@ By default, the backup retention is 30 days, but you can change it with the `--t
     ```bash
     velero backup -h
     ```
-2. Let’s start with the most basic option: creating a one off backup. It’s a good idea to give it a meaningful name so you remember what it was for unlike what is done here.
+2. Let’s start with the most basic option: creating a one off backup. It’s a
+   good idea to give it a meaningful name so you remember what it was for unlike
+   what is done here.
     ```bash
     BACKUP=gastly
     velero backup create $BACKUP --include-namespaces ghost
     ```
 
-    If we wanted to do a backup with all namespaces we can remove the `--include-namespaces` flag. And to include all namespaces except specific ones we could use `--exclude-namespaces` with the namespace(s) we don't want.
+    If we wanted to do a backup with all namespaces we can remove the
+    `--include-namespaces` flag. And to include all namespaces except specific
+    ones we could use `--exclude-namespaces` with the namespace(s) we don't
+    want.
 
 
 3. Let’s create a backup from a schedule. 
@@ -261,7 +353,8 @@ By default, the backup retention is 30 days, but you can change it with the `--t
     …
     ```
 
-5. [Optional] For both curiosity and debugging, it’s useful to do a `describe` and `logs` on your backups:
+5. [Optional] For both curiosity and debugging, it’s useful to do a `describe`
+   and `logs` on your backups:
     ```bash
     velero backup describe $BACKUP
 
@@ -269,24 +362,32 @@ By default, the backup retention is 30 days, but you can change it with the `--t
     ```
 
 ## 🔥Wreak Havoc🔥
-Now that we have a happy cluster state and that most excellent blog you created...let’s nuke Ghost. 
 
-Let’s say that _**someone**_ (you) “accidentally” (definitely intentionally) deleted the Ghost Helm chart and the persistent volume claim (PVC) by running the following:
+Now that we have a happy cluster state and that most excellent blog you
+created...let’s nuke Ghost.
+
+Let’s say that _**someone**_ (you) “accidentally” (definitely intentionally)
+deleted the Ghost Helm chart and the persistent volume claim (PVC) by running
+the following:
 ```bash
 helm delete --namespace ghost ghost
 kubectl -n ghost delete pvc data-ghost-mariadb-0
 ```
-Try to connect to Ghost again. Shoot... Now the blog site is down and so is that _**super important**_ blog post you just made. What now?
+Try to connect to Ghost again. Shoot... Now the blog site is down and so is that
+_**super important**_ blog post you just made. What now?
 
 ## Restore
-Well, it’s a good thing you have backups! Now it's time to look into restoring from a backup.
+
+Well, it’s a good thing you have backups! Now it's time to look into restoring
+from a backup.
 
 1. To see what all you can do with restore run:
     ```bash
     velero restore -h
     ```
     
-2. Let’s now wait for all of the resources to be gone. First check the output of `get all`:
+2. Let’s now wait for all of the resources to be gone. First check the output of
+   `get all`:
     ```bash
     kubectl -n ghost get all
     ```
@@ -294,7 +395,9 @@ Well, it’s a good thing you have backups! Now it's time to look into restoring
     ```bash
     kubectl get pvc
     ```
-    > Note: It might take a minute until everything is properly deleted; so you may run these commands above until they give you a (somewhat ominous) `No resources found` output.
+    Note: It might take a minute until everything is properly deleted; so you
+    may run these commands above until they give you a (somewhat ominous)
+    `No resources found` output.
 
 2. Now to perform a restore:
    
@@ -311,7 +414,8 @@ Well, it’s a good thing you have backups! Now it's time to look into restoring
    * Did all the resources come back up and therefore the Ghost site?
    * Is the _super important_ blog back, or only the default blogs?
 
-   * Let’s find out. First let’s check to see if our resources are back and running.
+   * Let’s find out. First let’s check to see if our resources are back and
+     running.
     ```bash
     kubectl -n ghost get all
 
@@ -333,30 +437,45 @@ Well, it’s a good thing you have backups! Now it's time to look into restoring
     statefulset.apps/ghost-mariadb   1/1     2m12s
     ```
 
-    Again, wait until all the pods above are `Running` with counts of `1/1` pods in `READY` state.
+    Again, wait until all the pods above are `Running` with counts of `1/1` pods
+    in `READY` state.
 
 4. Now get the `EXTERNAL_IP` from your service:
     ```bash
     kubectl get svc --namespace ghost ghost --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}"
     ```
 
-    > Note: Your IP address may have changed from earlier. For the depth of this specific demo it doesn't cause problems. However, to ensure all links work properly, update the `ghostHost` in `ghost-values.yaml` and run the [previous `helm upgrade`](#run-apps) command again. If we were using [`external-dns`](https://github.com/kubernetes-sigs/external-dns) and hostnames, it would automatically resolve itself.
+    {{% aside type="warning" title="Double check your IP" %}}
+Note: Your IP address may have changed from earlier. For the depth of this
+specific demo it doesn't cause problems. However, to ensure all links work
+properly, update the `ghostHost` in `ghost-values.yaml` and run the
+[previous `helm upgrade`](#run-apps) command again. If we were using
+[`external-dns`](https://github.com/kubernetes-sigs/external-dns) and
+hostnames, it would automatically resolve itself.
+    {{% /aside %}}
 
-    Now head to you the IP address in your browser and your blog should be up with the post you wrote!
+    Now head to you the IP address in your browser and your blog should be up
+    with the post you wrote!
 
-5. [Optional] For both curiosity and debugging, it’s useful to do a `describe` and `logs` on your restores:
+5. [Optional] For both curiosity and debugging, it’s useful to do a `describe`
+   and `logs` on your restores:
     ```bash
     velero restore describe <restore-name>
 
     velero restore logs <restore-name>
     ```
 
-As of Velero 1.5 [Restore Hooks](https://velero.io/docs/v1.5/restore-hooks/) are also available.
+As of Velero 1.5 [Restore Hooks](https://velero.io/docs/v1.5/restore-hooks/) are
+also available.
 
-For cluster migration (restoring from one cluster’s backup into another cluster) you can follow the [cluster migration documentation](https://velero.io/docs/v1.5/migration-case/).
+For cluster migration (restoring from one cluster’s backup into another cluster)
+you can follow the
+[cluster migration documentation](https://velero.io/docs/v1.5/migration-case/).
 
 ## Cleanup
-To delete the app resources, you can use `helm uninstall` and then delete the namespace:
+
+To delete the app resources, you can use `helm uninstall` and then delete the
+namespace:
 ```bash
 helm uninstall --namespace ghost ghost
 kubectl delete ns ghost
@@ -382,11 +501,12 @@ gsutil -m rm -r gs://$BUCKET
 ```
 
 ## Learn More
-Hopefully you found this guide helpful. Here are some other resources to help you learn more.
+
+Hopefully you found this guide helpful. Here are some other resources to help
+you learn more.
 
 * [Velero](https://velero.io/)
 * [Velero Documentation](https://velero.io/docs/latest/)
 * [Velero GitHub](https://github.com/vmware-tanzu/velero)
 * [Introduction to Velero Blog](https://velero.io/blog/Velero-is-an-Open-Source-Tool-to-Back-up-and-Migrate-Kubernetes-Clusters/)
 * [Quick start evaluation install with Minio](https://velero.io/docs/v1.5/contributions/minio/)
-


### PR DESCRIPTION
Use the aside shortcode to emphasize a particular block of text rather than treating it as a quotation.

Note: I did not simply replace every block quote with an aside, because there were quite a few occurrences of this pattern. If I felt like the text didn't need a super strong callout I just converted it to inline text.

Closes #567 