### PR TITLE
Removing aspnet guide from k8s topic since it's not using k8s

### DIFF
--- a/content/guides/containers/develop-aspnet-application-bitnami-containers.md
+++ b/content/guides/containers/develop-aspnet-application-bitnami-containers.md
@@ -7,7 +7,6 @@ description: Create, test, and publish a secure Docker image for an ASP.NET Web 
 date: 2020-09-03
 topics:
 - Containers
-- Kubernetes
 tags:
 - Bitnami
 - ASP.NET


### PR DESCRIPTION
This guide is tagged as kubernetes, but it is only container/docker level.