### PR TITLE
Fix project name

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in the
-Tanzu Community Edition project and our community a harassment-free experience
+Tanzu Developer Center project and our community a harassment-free experience
 for everyone, regardless of age, body size, visible or invisible disability,
 ethnicity, sex characteristics, gender identity and expression, level of
 experience, education, socio-economic status, nationality, personal appearance,


### PR DESCRIPTION
The code of conduct was referencing the wrong project.