### PR TITLE
spelling and dict changes to comply with VMware branding

### DIFF
--- a/content/blog/kubecon-europe-2021.md
+++ b/content/blog/kubecon-europe-2021.md
@@ -1,17 +1,17 @@
 ---
-title: "Kubecon EU 2021"
-description: VMware's Open Source projects as presented during KubeCon + CNC EU 2021 
+title: "KubeCon Europe 2021"
+description: VMware's Open Source projects as presented during KubeCon + CNC Europe 2021 
 date: "2021-04-30"
 # Author(s)
 team: 
 - Tony Vetter
 type: "blog"
-aliases: ["/kubeconeu2021"]
+aliases: ["/kubeconeurope2021"]
 ---
 
-## Greetings KubeCon + CNC EU Attendees!
+## Greetings KubeCon + CNC Europe Attendees!
 
-We hope you are enjoying your time at KubeCon and Cloud Native Conference! Hopefully, you have seen VMware's keynote presentation around just a hand full of the open source projects VMware is involved in. Well, if you are interested in learning more about those projects, and maybe even trying them out for yourself, you've come to the right place. Below, we have some great content for you to look through for each of these projects. Enjoy!
+We hope you are enjoying your time at KubeCon and CloudNativeCon! Hopefully, you have seen VMware's keynote presentation around just a hand full of the open source projects VMware is involved in. Well, if you are interested in learning more about those projects, and maybe even trying them out for yourself, you've come to the right place. Below, we have some great content for you to look through for each of these projects. Enjoy!
 
 ## Carvel
  

--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -230,6 +230,7 @@ Clojure
 closeRegion
 CloudEvents
 CloudHealth
+CloudNativeCon
 CloudWatch
 Clozel
 cluster-proportional-autoscaler
@@ -244,6 +245,7 @@ ClusterRoleBinding(s)?
 ClusterRoleBindings.
 CMD
 CNAME
+CNC
 CNCF
 CNI
 CNI-[Pp]lugin(s)?


### PR DESCRIPTION
change EU to Europe, and Cloud Native Con to CNC.