### PR TITLE
cf4k8s-gs.md install instr fix a yaml key and a CLI quote syntax

### DIFF
--- a/content/guides/kubernetes/cf4k8s-gs.md
+++ b/content/guides/kubernetes/cf4k8s-gs.md
@@ -120,7 +120,7 @@ Append the app_registry credentials to your DockerHub registry to the bottom of 
 cat >> cf-install-values.yml << EOL
 app_registry:
   hostname: https://index.docker.io/v1/
-  repository: "<DockerHub-username>"
+  repository_prefix: "<DockerHub-username>"
   username: "<DockerHub-username>"
   password: "<DockerHub-password>"
 EOL
@@ -143,7 +143,9 @@ EOL
 
 Now, use cf-install-values.yml to render the final Kubernetes template to raw Kubernetes configuration.
 
-ytt -f config -f ./cf-install-values.yml > ./cf-for-k8s-rendered.yml 
+```
+ytt -f config -f ./cf-install-values.yml > ./cf-for-k8s-rendered.yml
+```
 
 ## Deploy CF for k8s 
 


### PR DESCRIPTION
New users may have had trouble installing CF following this guide because of a recent regression. 

The name of the yaml key for the users dockerhub acct was changed from repository to repository_prefix for clarity on how it is used. Unfortunately this change has not made it back into this guide until now. 

In addition, the ytt config command at the end of the section Generate the yaml used to deploy CF for k8s needs to be run to complete setup, but it is not quoted in the same style as all of the other items. Adding the quote syntax as expected greatly improves readability