### PR TITLE
Move the git playbook under the correct pattern

### DIFF
--- a/content/guides/agile/git-playbook.md
+++ b/content/guides/agile/git-playbook.md
@@ -6,7 +6,7 @@ topics:
 tags:
 - Git
 patterns:
-- Deployment and Packaging
+- Deployment
 ---
 
 Git is a free and open source version control system that is widely used in the open source community, including well known git repositories such as GitHub and GitLab. If you are unfamiliar with Git, it’s worth taking a few moments to familiarize yourself with it.  A simple guide can be found at [http://rogerdudler.github.io/git-guide/](http://rogerdudler.github.io/git-guide/).


### PR DESCRIPTION
The pattern is called "Deployment", even though the display title is "Deployment and Packaging".

This removes the duplicate tile on the patterns page.

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/7527103/118562298-a97cc280-b729-11eb-8d67-4d62b5869090.png">
