### PR TITLE
Use a darker background colour for highlighted lines for dark theme

### DIFF
--- a/themes/docsy/assets/scss/_custom.scss
+++ b/themes/docsy/assets/scss/_custom.scss
@@ -1266,7 +1266,7 @@ code {
 .chroma .hl {
   display: block;
   width: 100%;
-  background-color: #ffffcc;
+  background-color: #323232;
 }
 /* LineNumbersTable */
 .chroma .lnt {


### PR DESCRIPTION
(By "highlighting", I'm referring to Hugo's highlighting: https://gohugo.io/content-management/syntax-highlighting/#example-highlight-shortcode)

At the moment, the same background colour is used for highlighted lines in both light and dark theme.

Light theme:

<img width="842" alt="Screen Shot 2021-06-01 at 6 15 35 PM" src="https://user-images.githubusercontent.com/61553/120307279-5f890480-c305-11eb-8c6e-d32ac329c45a.png">

Dark theme:

<img width="842" alt="Screen Shot 2021-06-01 at 6 17 14 PM" src="https://user-images.githubusercontent.com/61553/120307487-a1b24600-c305-11eb-9d10-37506f0cdba5.png">

While the background colour was ok for the light theme, it's a little too sharp a contrast when using the dark theme. Here's what it looks like with this PR:

<img width="863" alt="Screen Shot 2021-06-01 at 5 21 21 PM" src="https://user-images.githubusercontent.com/61553/120306938-fdc89a80-c304-11eb-9458-f614245fe89c.png">

(I used the background colour from solarized-256, in case anyone's wondering https://github.com/xyproto/splash/search?q=%22.chroma+.hl%22)