### PR TITLE
Add stale notice.

### DIFF
--- a/themes/docsy/layouts/guides/content.html
+++ b/themes/docsy/layouts/guides/content.html
@@ -1,6 +1,7 @@
 
 	<h1>{{ .Title | markdownify }}</h1>
 	{{ partial "byline" (dict "context" . "withdate" false) }}
+	{{ partial "stale-notice" (dict "context" . "contentType" "guide") }}
 	<!--{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}-->
 	{{ .Content }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}

--- a/themes/docsy/layouts/partials/stale-notice.html
+++ b/themes/docsy/layouts/partials/stale-notice.html
@@ -1,0 +1,3 @@
+{{ if now.After (.context.Params.lastmod.AddDate 1 0 ) }}
+    <div class="alert alert-warning">This {{ .contentType }} is over a year old and may not be completely up-to-date.</div>
+{{ end }}

--- a/themes/docsy/layouts/partials/stale-notice.html
+++ b/themes/docsy/layouts/partials/stale-notice.html
@@ -1,3 +1,3 @@
-{{ if now.After (.context.Params.lastmod.AddDate 1 0 ) }}
+{{ if now.After (.context.Params.lastmod.AddDate 1 0 0) }}
     <div class="alert alert-warning">This {{ .contentType }} is over a year old and may not be completely up-to-date.</div>
 {{ end }}

--- a/themes/docsy/layouts/workshops/single.html
+++ b/themes/docsy/layouts/workshops/single.html
@@ -58,6 +58,7 @@
 	{{end}}
 </div>
 <div class='container'>
+	{{ partial "stale-notice" (dict "context" . "contentType" "workshop") }}
 	<hr class='border-bottom'>
 </div>
 <div class="container github-imported-sample py-lg-5 py-2 mb-5 d-flex">


### PR DESCRIPTION
PoC of a 'stale' notice. Thoughts welcome :)

Triggers if the `.lastmod` is over a year old. Don't think any content actually triggers that yet, so image below shows what it looks like. Only added on guides and samples at the moment.

![stale](https://user-images.githubusercontent.com/746221/122453621-6a77a200-cf5f-11eb-9c39-3e05c7b3bcf9.png)

Signed-off-by: John Harris <joharris@vmware.com>