### PR TITLE
add team-member template to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ video.%:
 practice.%:
 	hugo new practices/$(call word-dot,$*,1)/index.md -k practices
 
+#team: @ creates a new team page. example: make team.firstname-lastname
+team.%:
+	hugo new team/$(call word-dot,$*,1)/_index.md -k team-member
+
 #audit: @ runs a content audit on all guides and blogs. example: make audit
 audit:
 	cd .github/actions/audit/src && bundle install

--- a/archetypes/team-member.md
+++ b/archetypes/team-member.md
@@ -1,5 +1,5 @@
 ---
-name: Full Name
+name: "{{ replace .Name "-" " " | title }}"
 description: "Job Title"
 photo: ""
 roles: ["author","advocate"]


### PR DESCRIPTION
Allowing templates to be generated for the team-member template (e.g. `make team.firstname-lastname`)