### PR TITLE
Set table text to white in the dark theme in tables included in outcomes

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -166,6 +166,10 @@ body {
     border-bottom-color: rgb(222, 226, 230);
   }
   
+  .table tbody tr {
+    color: white;
+  }
+
   p {
     font-size: 1.0625rem;
     margin: 1rem 0;


### PR DESCRIPTION
Fixes an issue where text in tables -- only in outcomes -- was set to be a dark color in the dark theme