### PR TITLE
add `.hugo_build.lock` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Local Netlify folder
 .netlify
+
+# Hugo lock file
+.hugo_build.lock


### PR DESCRIPTION
From Hugo:
```
A little longer explanation:
* We rewrote archetypes in this release
* When you run hugo new ... with archetype directories with lots of images etc., that would earlier trigger lots of changes if you had a running server and also some issues with building from partially written files.
* Now when you do hugo new ... we acquire a write lock (OS level) on .hugo_build.lock before we write to /content and then release the lock when done.
* The same lock is acquired and released on every hugo build and also all rebuilds when running a server.
```
Adding this file to `.gitignore`