### PR TITLE
Update content - Remove "part 1" from title

### DIFF
--- a/content/guides/supply-chain-choreography/index.md
+++ b/content/guides/supply-chain-choreography/index.md
@@ -5,7 +5,7 @@ tags:
 - CI-CD
 team:
 - Daniel de Repentigny
-title: Software Supply Chain Choreography, Part 1
+title: Software Supply Chain Choreography
 level1: Deploying Modern Applications
 level2: CI/CD, Release Pipelines
 aliases:


### PR DESCRIPTION
From the Supply Chain Choreography guide. Added alias. 