### PR TITLE
adding a note about using the hyperkit driver on MacOS

### DIFF
--- a/content/guides/tanzu-application-platform-local-devloper-install/index.md
+++ b/content/guides/tanzu-application-platform-local-devloper-install/index.md
@@ -269,7 +269,7 @@ minikube start --cpus='8' --memory='12g' --kubernetes-version='1.22.6'
 ```
 
 {{% info %}}
-In MacOS we tested with Docker as the VM driver. If you hit issues with this driver, you could try `--driver='hyperkit'` to force the use of [Hyperkit](https://github.com/moby/hyperkit) as Minikube's VM driver. To discover your VM driver, after you have run `minikube start` use the command `minikube profile list`.
+In MacOS we tested with Docker as the VM driver. If you hit issues with this driver, you could try `--driver='hyperkit'` to force the use of [HyperKit](https://github.com/moby/hyperkit) as Minikube's VM driver. To discover your VM driver, after you have run `minikube start` use the command `minikube profile list`.
 {{% /info %}}
 
 {{< /tab >}}

--- a/content/guides/tanzu-application-platform-local-devloper-install/index.md
+++ b/content/guides/tanzu-application-platform-local-devloper-install/index.md
@@ -268,6 +268,10 @@ In Windows 10 we tested using [Hyper-V](https://docs.microsoft.com/en-us/virtual
 minikube start --cpus='8' --memory='12g' --kubernetes-version='1.22.6'
 ```
 
+{{% info %}}
+In MacOS we tested with Docker as the VM driver. If you hit issues with this driver, you could try `--driver='hyperkit'` to force the use of [Hyperkit](https://github.com/moby/hyperkit) as Minikube's VM driver. To discover your VM driver, after you have run `minikube start` use the command `minikube profile list`.
+{{% /info %}}
+
 {{< /tab >}}
 {{< tab header="Linux" >}}
 


### PR DESCRIPTION
Some folks report issues with Mikukube's default Docker driver (on MacOS). In some cases this driver is not providing the tunnel functionality required to expose access to K8s applications from the host machine. Some report that Hyperkit does a better job. So I've added a note about the option of using Hyperkit to the MacOS instructions.