### PR TITLE
Add "test-docker" target to Makefile to run all tests in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:18-alpine3.15
+
+WORKDIR /home
+
+ENV HUGO_VERSION='0.82.0'
+ENV MUFFET_VERSION='2.4.4'
+
+# Add required packages (libc6-compat required to get hugo to work)
+RUN apk add --no-cache curl libc6-compat git
+
+# Install Hugo
+ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
+ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.tar.gz"
+RUN wget "${HUGO_URL}" && \
+    tar -zxvf "${HUGO_NAME}.tar.gz" && \
+    mv ./hugo /usr/local/bin/
+
+# Install spellchecker
+RUN npm install --global spellchecker-cli retext-syntax-urls retext-indefinite-article retext-repeated-words remark-frontmatter --loglevel verbose
+
+# Install muffet
+ENV MUFFET_NAME="muffet_${MUFFET_VERSION}_Linux_x86_64"
+ENV MUFFET_URL="https://github.com/raviqqe/muffet/releases/download/v${MUFFET_VERSION}/${MUFFET_NAME}.tar.gz"
+RUN wget "${MUFFET_URL}" && \
+    tar -zxvf "${MUFFET_NAME}.tar.gz" && \
+    mv muffet /usr/local/bin
+
+WORKDIR /home/tdc

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ build: npm
 test: npm
 	act pull_request
 
+#test-docker @ Build a Docker container and runs the tests
+test-docker: npm
+	docker build -t tanzu-dev-center-tests:latest .
+	docker run -it --entrypoint ./test/run.sh -v ${PWD}:/home/tdc tanzu-dev-center-tests:latest
+
 #spell: @ runs act to perform spellcheck
 spell: npm
 	act -j spell-check

--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -10,7 +10,6 @@
 [0-9]*(GB|MB|M|KB|Mi|m|m?s|k)
 [R,r]eplatform
 (?:[APMCEI][ESD]T|UTC)
-queryable
 .tgz
 1:1s
 10x
@@ -52,7 +51,6 @@ addAndReturnSizes
 AddCloudFoundry
 AddConfigServer
 AddEnvironmentVariables
-StarTree
 additively
 addNotificationListener
 Addon
@@ -1775,6 +1773,7 @@ Pythonic
 QCon
 QoS
 Querier
+queryable
 queuedEvents
 QueueStatistics
 Quickstart
@@ -2066,6 +2065,7 @@ Standley
 starbuxman
 STARGATE|Stargate
 Starlark
+StarTree
 startupProbe(s)?
 stateful
 StatefulSet(s)?

--- a/test/links.sh
+++ b/test/links.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -o pipefail
+
+LOCAL_HOST="http://localhost:1313/developer"
+MAX_WAIT_TIME=600 # 5 min
+
+HUGO_OPTIONS="-b $LOCAL_HOST"
+MUFFET_OPTIONS="-t 30 -c 5 -e 'https?' --exclude='/developer/get-workshop'" 
+
+echo "--> Start hugo server"
+eval hugo server "${HUGO_OPTIONS}" > /dev/null &
+echo -n "--> Wait for hugo server to start..."
+for i in $(seq 0 ${MAX_WAIT_TIME}); do # 5 min
+    sleep 0.5
+    IS_SERVER_RUNNING=$(curl -LI ${LOCAL_HOST} -o /dev/null -w '%{http_code}' -s)
+    if [[ "${IS_SERVER_RUNNING}" == "200" ]]; then
+        echo "server started."
+        echo "--> Check for broken links"
+        eval muffet "${MUFFET_OPTIONS}" ${LOCAL_HOST} | tee /tmp/output.txt
+        if [ $? -eq 0 ]; then
+            echo "--> No broken links! "
+            exit 0
+        else
+            echo "--> Broken links found:"
+            grep 404 /tmp/output.txt
+            exit 1
+        fi
+    fi
+done
+
+echo "error: time out" && exit 1

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' 
+
+
+# Spellcheck
+./test/spellcheck.sh
+RSLT_SPELL=$?
+
+# Broken links
+./test/links.sh
+RSLT_LINKS=$?
+
+# Print results
+if [ $RSLT_SPELL -eq 0 ]; then
+    echo -e "Spellcheck: ${GREEN}PASSED${NC}"
+else
+    echo -e "Spellcheck: ${RED}FAILED${NC}"
+fi
+
+if [ $RSLT_LINKS -eq 0 ]; then
+    echo -e "Link Check: ${GREEN}PASSED${NC}"
+else
+    echo -e "Link Check: ${RED}FAILED${NC}"
+fi

--- a/test/spellcheck.sh
+++ b/test/spellcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o pipefail
+
+echo "--> spellcheck markdown files"
+IGNORE_REGEX="[0-9a-f]{7} (?=.*[0-9])[0-9A-Za-z_\-]{11}" # GitHub hashes and YouTube IDs
+IGNORE_FILES="!(content/tv/tgik/**/index.md) !(content/tv/talk/**/index.md)" # Don't worry about TGIK/Tanzu Talk episodes for now as they scrape from YT
+spellchecker -q --no-suggestions -l en-US -f 'content/**/*.md' $IGNORE_FILES -i $IGNORE_REGEX --frontmatter-keys title Title description Description -d custom_dict.txt --plugins frontmatter spell syntax-urls indefinite-article repeated-words


### PR DESCRIPTION
Ideally we eventually build a package hosted here that gets pulled down rather than built locally, but we've recently been having issues with local tests failing to run (namely the link check) using the `act` CLI. This adds a target to the Makefile to build a container image and then run the spelling and link checks (will add the topic check, but that will require a separate effort to keep the image from exploding in size)

To test, in this branch you can simply run `make test-docker` if you have Docker running

After the container is built, it runs runs the container, mounting the current working directory at `/home/tdc` and runs the `test/run.sh` command. This means any changes made locally are reflected in each run.